### PR TITLE
feat: in-app update checker and sidecar updater daemon

### DIFF
--- a/Overlord-Server/public/assets/settings.js
+++ b/Overlord-Server/public/assets/settings.js
@@ -62,6 +62,22 @@ const appearancePermissionNote = document.getElementById("appearance-permission-
 const appearanceSaveBtn = document.getElementById("appearance-save-btn");
 const appearanceCustomCssInput = document.getElementById("appearance-custom-css");
 
+const updateSection = document.getElementById("update-section");
+const updateVersionLabel = document.getElementById("update-version-label");
+const updateStatusText = document.getElementById("update-status-text");
+const updateCheckBtn = document.getElementById("update-check-btn");
+const updateAvailablePanel = document.getElementById("update-available-panel");
+const updateNewVersion = document.getElementById("update-new-version");
+const updateApplyBtn = document.getElementById("update-apply-btn");
+const updateUpToDatePanel = document.getElementById("update-up-to-date-panel");
+const updateProgressPanel = document.getElementById("update-progress-panel");
+const updateProgressTitle = document.getElementById("update-progress-title");
+const updateProgressBar = document.getElementById("update-progress-bar");
+const updateProgressMessage = document.getElementById("update-progress-message");
+const updateProgressLog = document.getElementById("update-progress-log");
+const updateErrorPanel = document.getElementById("update-error-panel");
+const updateErrorText = document.getElementById("update-error-text");
+
 const exportImportSection = document.getElementById("export-import-section");
 const exportSettingsBtn = document.getElementById("export-settings-btn");
 const importSettingsFile = document.getElementById("import-settings-file");
@@ -827,6 +843,209 @@ async function wipeOfflineClients() {
   }
 }
 
+// ---- In-app update ----
+
+let latestUpdateCheck = null;
+let updatePollTimer = null;
+
+function hideAllUpdatePanels() {
+  [updateAvailablePanel, updateUpToDatePanel, updateProgressPanel, updateErrorPanel].forEach(
+    (el) => el && el.classList.add("hidden"),
+  );
+}
+
+async function checkForUpdates() {
+  if (!updateCheckBtn) return;
+  updateCheckBtn.disabled = true;
+  updateCheckBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin mr-1"></i>Checking...';
+  hideAllUpdatePanels();
+
+  try {
+    const res = await fetch("/api/update/check", { credentials: "include" });
+    const data = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      if (updateErrorPanel && updateErrorText) {
+        updateErrorText.textContent = data.error || "Update check failed.";
+        updateErrorPanel.classList.remove("hidden");
+      }
+      return;
+    }
+
+    latestUpdateCheck = data;
+    if (updateVersionLabel) updateVersionLabel.textContent = data.currentVersion || "-";
+    if (updateStatusText) updateStatusText.textContent = `Last checked: ${new Date().toLocaleTimeString()}`;
+
+    if (data.updateAvailable) {
+      if (updateNewVersion) updateNewVersion.textContent = data.latestVersion;
+      if (updateAvailablePanel) updateAvailablePanel.classList.remove("hidden");
+    } else {
+      if (updateUpToDatePanel) updateUpToDatePanel.classList.remove("hidden");
+    }
+  } catch (err) {
+    if (updateErrorPanel && updateErrorText) {
+      updateErrorText.textContent = `Network error: ${err.message || err}`;
+      updateErrorPanel.classList.remove("hidden");
+    }
+  } finally {
+    updateCheckBtn.disabled = false;
+    updateCheckBtn.innerHTML = '<i class="fa-solid fa-magnifying-glass mr-1"></i>Check for Updates';
+  }
+}
+
+async function applyUpdate() {
+  if (!latestUpdateCheck?.latestVersion) return;
+  if (!confirm(`Update Overlord to version ${latestUpdateCheck.latestVersion}?\n\nThe server will restart during the update. You may briefly lose connection.`)) return;
+
+  if (updateApplyBtn) {
+    updateApplyBtn.disabled = true;
+    updateApplyBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin mr-1"></i>Requesting...';
+  }
+
+  try {
+    const res = await fetch("/api/update/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ targetVersion: latestUpdateCheck.latestVersion }),
+    });
+
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      if (updateErrorPanel && updateErrorText) {
+        updateErrorText.textContent = data.error || "Failed to start update.";
+        updateErrorPanel.classList.remove("hidden");
+      }
+      return;
+    }
+
+    hideAllUpdatePanels();
+    if (updateProgressPanel) updateProgressPanel.classList.remove("hidden");
+    if (updateProgressMessage) updateProgressMessage.textContent = "Waiting for host updater to pick up the request...";
+    if (updateProgressBar) updateProgressBar.style.width = "5%";
+    startUpdatePolling();
+  } catch (err) {
+    if (updateErrorPanel && updateErrorText) {
+      updateErrorText.textContent = `Network error: ${err.message || err}`;
+      updateErrorPanel.classList.remove("hidden");
+    }
+  } finally {
+    if (updateApplyBtn) {
+      updateApplyBtn.disabled = false;
+      updateApplyBtn.innerHTML = '<i class="fa-solid fa-rocket mr-1"></i>Apply Update';
+    }
+  }
+}
+
+function startUpdatePolling() {
+  if (updatePollTimer) clearInterval(updatePollTimer);
+  updatePollTimer = setInterval(pollUpdateStatus, 3000);
+  pollUpdateStatus();
+}
+
+async function pollUpdateStatus() {
+  try {
+    const res = await fetch("/api/update/status", { credentials: "include" });
+    if (!res.ok) return;
+    const status = await res.json().catch(() => null);
+    if (!status) return;
+
+    if (status.state === "idle" && status.updatedAt === 0) return;
+
+    hideAllUpdatePanels();
+    if (updateProgressPanel) updateProgressPanel.classList.remove("hidden");
+
+    if (updateProgressBar) updateProgressBar.style.width = `${status.progress || 0}%`;
+    if (updateProgressMessage) updateProgressMessage.textContent = status.message || "";
+
+    const stateLabels = {
+      pending: "Update pending...",
+      pulling: "Pulling new image from registry...",
+      restarting: "Restarting container...",
+      done: "Update complete!",
+      error: "Update failed",
+    };
+    if (updateProgressTitle) {
+      updateProgressTitle.textContent = stateLabels[status.state] || `State: ${status.state}`;
+    }
+
+    if (status.log && status.log.length && updateProgressLog) {
+      updateProgressLog.classList.remove("hidden");
+      updateProgressLog.textContent = status.log.join("\n");
+      updateProgressLog.scrollTop = updateProgressLog.scrollHeight;
+    }
+
+    if (status.state === "done") {
+      if (updatePollTimer) clearInterval(updatePollTimer);
+      await fetch("/api/update/reset", { method: "POST", credentials: "include" }).catch(() => {});
+      hideAllUpdatePanels();
+      const toast = document.createElement("p");
+      toast.className = "text-sm text-emerald-400 flex items-center gap-2";
+      toast.innerHTML = '<i class="fa-solid fa-circle-check"></i>Update complete!';
+      updateSection?.prepend(toast);
+      setTimeout(() => toast.remove(), 4000);
+    }
+
+    if (status.state === "error") {
+      if (updatePollTimer) clearInterval(updatePollTimer);
+      hideAllUpdatePanels();
+      if (updateErrorPanel && updateErrorText) {
+        updateErrorText.textContent = status.message || "Update failed. Check logs.";
+        updateErrorPanel.classList.remove("hidden");
+      }
+    }
+  } catch {
+    // Server may be restarting - keep polling
+  }
+}
+
+async function initUpdateSection() {
+  if (!isAdmin(currentUser?.role) || !updateSection) return;
+  updateSection.classList.remove("hidden");
+
+  // Fetch current version
+  try {
+    const res = await fetch("/api/version", { credentials: "include" });
+    if (res.ok) {
+      const data = await res.json();
+      if (updateVersionLabel) updateVersionLabel.textContent = data.version || "-";
+    }
+  } catch {}
+
+  // Check if an update is already in progress or recently completed
+  try {
+    const res = await fetch("/api/update/status", { credentials: "include" });
+    if (res.ok) {
+      const status = await res.json();
+      if (status.state === "done") {
+        // Clear the status file so future page loads start fresh
+        await fetch("/api/update/reset", { method: "POST", credentials: "include" }).catch(() => {});
+        // Briefly show a success toast then restore the normal check-for-updates UI
+        hideAllUpdatePanels();
+        const toast = document.createElement("p");
+        toast.className = "text-sm text-emerald-400 flex items-center gap-2";
+        toast.innerHTML = '<i class="fa-solid fa-circle-check"></i>Last update completed successfully.';
+        updateSection?.prepend(toast);
+        setTimeout(() => toast.remove(), 4000);
+      } else if (status.state === "error") {
+        hideAllUpdatePanels();
+        if (updateErrorPanel && updateErrorText) {
+          updateErrorText.textContent = status.message || "Last update failed.";
+          updateErrorPanel.classList.remove("hidden");
+        }
+      } else if (status.state && status.state !== "idle") {
+        // In-progress — resume live polling
+        hideAllUpdatePanels();
+        if (updateProgressPanel) updateProgressPanel.classList.remove("hidden");
+        startUpdatePolling();
+      }
+    }
+  } catch {}
+
+  if (updateCheckBtn) updateCheckBtn.addEventListener("click", checkForUpdates);
+  if (updateApplyBtn) updateApplyBtn.addEventListener("click", applyUpdate);
+}
+
 async function init() {
   try {
     await loadCurrentUser();
@@ -840,6 +1059,7 @@ async function init() {
       wipeOfflineSection.classList.remove("hidden");
     }
 
+    await initUpdateSection();
     await loadSecurityPolicy();
     await loadTlsSettings();
     await loadAppearanceSettings();

--- a/Overlord-Server/public/index.html
+++ b/Overlord-Server/public/index.html
@@ -34,6 +34,11 @@
   </head>
   <body class="min-h-screen bg-slate-950 text-slate-100">
     <header id="top-nav"></header>
+    <div id="update-banner" class="hidden bg-green-900/80 border-b border-green-700/60 px-4 py-2 text-center text-sm">
+      <i class="fa-solid fa-circle-up text-green-400 mr-1"></i>
+      <span class="text-green-100">A new version of Overlord is available: <strong id="update-banner-version"></strong></span>
+      <a href="/settings" class="ml-2 text-green-300 hover:text-green-100 underline font-medium">Update now</a>
+    </div>
     <main class="px-5 py-6">
       <div id="clients-shell" class="w-full flex flex-col gap-5">
         <div class="flex items-center justify-between gap-3 flex-wrap">
@@ -177,5 +182,23 @@
     <script src="/assets/toast.js"></script>
     <script src="/assets/ripple.js"></script>
     <script type="module" src="/assets/main.js"></script>
+    <script>
+      // Background update check for admin users
+      (async function checkUpdateBanner() {
+        try {
+          const me = await fetch("/api/auth/me", { credentials: "include" }).then(r => r.ok ? r.json() : null);
+          if (!me || me.role !== "admin") return;
+          const data = await fetch("/api/update/check", { credentials: "include" }).then(r => r.ok ? r.json() : null);
+          if (data && data.updateAvailable) {
+            const banner = document.getElementById("update-banner");
+            const versionEl = document.getElementById("update-banner-version");
+            if (banner && versionEl) {
+              versionEl.textContent = "v" + data.latestVersion;
+              banner.classList.remove("hidden");
+            }
+          }
+        } catch {}
+      })();
+    </script>
   </body>
 </html>

--- a/Overlord-Server/public/settings.html
+++ b/Overlord-Server/public/settings.html
@@ -55,6 +55,76 @@
         </div>
       </section>
 
+      <section id="update-section" class="hidden bg-slate-900/60 border border-slate-800 rounded-xl p-5 space-y-4">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-green-500/10 border border-green-500/30">
+            <i class="fa-solid fa-cloud-arrow-down text-green-400"></i>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold">Software Update</h2>
+            <p class="text-sm text-slate-400">Check for and install Overlord updates from the container registry.</p>
+          </div>
+        </div>
+
+        <div id="update-current-version" class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-3">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm text-slate-300">Current version: <span id="update-version-label" class="font-mono font-semibold text-slate-100">-</span></p>
+              <p id="update-status-text" class="text-xs text-slate-500 mt-0.5">Click "Check for Updates" to see if a new version is available.</p>
+            </div>
+            <button
+              id="update-check-btn"
+              type="button"
+              class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-green-700 hover:bg-green-600 transition-colors text-white text-sm font-medium whitespace-nowrap"
+            >
+              <i class="fa-solid fa-magnifying-glass"></i>
+              Check for Updates
+            </button>
+          </div>
+        </div>
+
+        <div id="update-available-panel" class="hidden rounded-lg border border-green-700/50 bg-green-900/20 px-4 py-4 space-y-3">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-sm font-semibold text-green-200">
+                <i class="fa-solid fa-circle-up mr-1"></i>
+                Update available: <span id="update-new-version" class="font-mono">-</span>
+              </p>
+            </div>
+            <button
+              id="update-apply-btn"
+              type="button"
+              class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 hover:bg-green-500 transition-colors text-white text-sm font-medium whitespace-nowrap"
+            >
+              <i class="fa-solid fa-rocket"></i>
+              Apply Update
+            </button>
+          </div>
+        </div>
+
+        <div id="update-up-to-date-panel" class="hidden rounded-lg border border-slate-700 bg-slate-900 px-4 py-3">
+          <p class="text-sm text-emerald-300"><i class="fa-solid fa-circle-check mr-1"></i> You are running the latest version.</p>
+        </div>
+
+        <div id="update-progress-panel" class="hidden rounded-lg border border-sky-700/50 bg-sky-900/20 px-4 py-4 space-y-3">
+          <div class="flex items-center gap-2">
+            <i class="fa-solid fa-spinner fa-spin text-sky-400"></i>
+            <p id="update-progress-title" class="text-sm font-semibold text-sky-200">Update in progress...</p>
+          </div>
+          <div class="w-full bg-slate-800 rounded-full h-2.5">
+            <div id="update-progress-bar" class="bg-sky-500 h-2.5 rounded-full transition-all duration-500" style="width: 0%"></div>
+          </div>
+          <p id="update-progress-message" class="text-xs text-slate-400"></p>
+          <pre id="update-progress-log" class="hidden text-xs text-slate-400 bg-slate-950 rounded-lg p-3 max-h-48 overflow-y-auto font-mono"></pre>
+        </div>
+
+        <div id="update-error-panel" class="hidden rounded-lg border border-red-700/50 bg-red-900/20 px-4 py-3">
+          <p class="text-sm text-red-300"><i class="fa-solid fa-triangle-exclamation mr-1"></i> <span id="update-error-text"></span></p>
+        </div>
+
+        <p id="update-message" class="hidden text-sm rounded-lg px-3 py-2 border"></p>
+      </section>
+
       <section id="export-import-section" class="hidden bg-slate-900/60 border border-slate-800 rounded-xl p-5 space-y-4">
         <div class="flex items-center gap-3">
           <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-500/10 border border-amber-500/30">

--- a/Overlord-Server/src/server/routes/misc-routes.ts
+++ b/Overlord-Server/src/server/routes/misc-routes.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../logger";
 import { authenticateRequest } from "../../auth";
 import { AuditAction, getAuditLogs, logAudit } from "../../auditLog";
 import { getConfig, updateSecurityConfig, updateTlsConfig, updateAppearanceConfig, getExportableConfig, importFullConfig } from "../../config";
@@ -11,6 +12,13 @@ import {
   startProxy,
   stopProxy,
 } from "../socks5-proxy-manager";
+import {
+  checkForUpdate,
+  writeUpdateRequest,
+  readUpdateStatus,
+  hasPendingRequest,
+  clearUpdateStatus,
+} from "../update-checker";
 
 type MiscRouteDeps = {
   CORS_HEADERS: Record<string, string>;
@@ -517,6 +525,102 @@ export async function handleMiscRoutes(
 
       return Response.json({ ok: true, customCSS: updated.customCSS }, { headers: deps.CORS_HEADERS });
     }
+  }
+
+  // ---- In-app update endpoints ----
+
+  if (req.method === "GET" && url.pathname === "/api/update/check") {
+    const user = await authenticateRequest(req);
+    if (!user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    if (user.role !== "admin") {
+      return new Response("Forbidden: Admin access required", { status: 403 });
+    }
+
+    try {
+      const result = await checkForUpdate(deps.SERVER_VERSION);
+      return Response.json(result, { headers: deps.CORS_HEADERS });
+    } catch (error: any) {
+      logger.error("[update] check failed", error);
+      return Response.json(
+        { error: String(error?.message || "Update check failed") },
+        { status: 502, headers: deps.CORS_HEADERS },
+      );
+    }
+  }
+
+  if (req.method === "POST" && url.pathname === "/api/update/start") {
+    const user = await authenticateRequest(req);
+    if (!user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    if (user.role !== "admin") {
+      return new Response("Forbidden: Admin access required", { status: 403 });
+    }
+
+    let body: any = {};
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const targetVersion = typeof body?.targetVersion === "string" ? body.targetVersion.trim() : "";
+    if (!targetVersion) {
+      return Response.json({ error: "targetVersion is required" }, { status: 400 });
+    }
+
+    const pending = await hasPendingRequest();
+    if (pending) {
+      return Response.json(
+        { error: "An update is already pending. Wait for it to complete or check status." },
+        { status: 409, headers: deps.CORS_HEADERS },
+      );
+    }
+
+    await writeUpdateRequest({
+      requestedAt: Date.now(),
+      requestedBy: user.username,
+      targetVersion,
+    });
+
+    logAudit({
+      timestamp: Date.now(),
+      username: user.username,
+      ip: deps.requestIP?.(req)?.address || "unknown",
+      action: AuditAction.COMMAND,
+      details: `Triggered in-app update to version ${targetVersion}`,
+      success: true,
+    });
+
+    return Response.json({ ok: true, message: "Update requested. The host updater will process it shortly." }, { headers: deps.CORS_HEADERS });
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/update/status") {
+    const user = await authenticateRequest(req);
+    if (!user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    if (user.role !== "admin") {
+      return new Response("Forbidden: Admin access required", { status: 403 });
+    }
+
+    const status = await readUpdateStatus();
+    return Response.json(status, { headers: deps.CORS_HEADERS });
+  }
+
+  if (req.method === "POST" && url.pathname === "/api/update/reset") {
+    const user = await authenticateRequest(req);
+    if (!user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    if (user.role !== "admin") {
+      return new Response("Forbidden: Admin access required", { status: 403 });
+    }
+
+    await clearUpdateStatus();
+    return Response.json({ ok: true }, { headers: deps.CORS_HEADERS });
   }
 
   if (req.method === "GET" && url.pathname === "/api/cert/download" && deps.tlsCertPath) {

--- a/Overlord-Server/src/server/update-checker.test.ts
+++ b/Overlord-Server/src/server/update-checker.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { parseVersion, isNewerVersion, findHighestSemverTag } from "./update-checker";
+
+describe("parseVersion", () => {
+  test("parses semver", () => { expect(parseVersion("1.7.0")).toEqual([1, 7, 0]); });
+  test("strips v", () => { expect(parseVersion("v2.0.1")).toEqual([2, 0, 1]); });
+  test("null for invalid", () => { expect(parseVersion("bad")).toBeNull(); });
+  test("null for empty", () => { expect(parseVersion("")).toBeNull(); });
+  test("parses with extra suffix", () => { expect(parseVersion("1.2.3-beta")).toEqual([1, 2, 3]); });
+});
+
+describe("isNewerVersion", () => {
+  test("major bump", () => { expect(isNewerVersion("1.7.0", "2.0.0")).toBe(true); });
+  test("minor bump", () => { expect(isNewerVersion("1.7.0", "1.8.0")).toBe(true); });
+  test("patch bump", () => { expect(isNewerVersion("1.7.0", "1.7.1")).toBe(true); });
+  test("same", () => { expect(isNewerVersion("1.7.0", "1.7.0")).toBe(false); });
+  test("older", () => { expect(isNewerVersion("2.0.0", "1.9.9")).toBe(false); });
+  test("invalid local", () => { expect(isNewerVersion("bad", "1.0.0")).toBe(false); });
+  test("invalid remote", () => { expect(isNewerVersion("1.0.0", "bad")).toBe(false); });
+});
+
+describe("findHighestSemverTag", () => {
+  test("finds highest version", () => {
+    expect(findHighestSemverTag(["1.0.0", "1.7.1", "1.7.0", "latest", "sha-abc123"])).toBe("1.7.1");
+  });
+
+  test("handles v-prefixed tags", () => {
+    expect(findHighestSemverTag(["v1.0.0", "v2.1.0", "latest"])).toBe("2.1.0");
+  });
+
+  test("returns null for no semver tags", () => {
+    expect(findHighestSemverTag(["latest", "main", "sha-abc"])).toBeNull();
+  });
+
+  test("returns null for empty list", () => {
+    expect(findHighestSemverTag([])).toBeNull();
+  });
+
+  test("single semver tag", () => {
+    expect(findHighestSemverTag(["1.8.0"])).toBe("1.8.0");
+  });
+
+  test("correctly compares across major versions", () => {
+    expect(findHighestSemverTag(["1.9.9", "2.0.0", "1.10.0"])).toBe("2.0.0");
+  });
+});

--- a/Overlord-Server/src/server/update-checker.ts
+++ b/Overlord-Server/src/server/update-checker.ts
@@ -1,0 +1,204 @@
+/**
+ * In-app update checker.
+ *
+ * - Queries the GHCR (GitHub Container Registry) OCI API for available image
+ *   tags of ghcr.io/vxaboveground/overlord and compares the latest semver tag
+ *   to SERVER_VERSION.
+ * - Writes/reads trigger and status files in the data directory so the host-side
+ *   updater daemon can pick up requests and report progress.
+ */
+
+import { resolve } from "path";
+import { ensureDataDir } from "../paths";
+import { logger } from "../logger";
+
+const dataDir = ensureDataDir();
+
+const UPDATE_REQUEST_FILE = resolve(dataDir, "update-request.json");
+const UPDATE_STATUS_FILE = resolve(dataDir, "update-status.json");
+
+const GHCR_IMAGE = "vxaboveground/overlord";
+
+// ---- Semver helpers ----
+
+export function parseVersion(v: string): [number, number, number] | null {
+  const m = v.replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** Returns true when `remote` is strictly newer than `local`. */
+export function isNewerVersion(local: string, remote: string): boolean {
+  const l = parseVersion(local);
+  const r = parseVersion(remote);
+  if (!l || !r) return false;
+  for (let i = 0; i < 3; i++) {
+    if (r[i] > l[i]) return true;
+    if (r[i] < l[i]) return false;
+  }
+  return false;
+}
+
+// ---- GHCR registry check ----
+
+export type UpdateCheckResult = {
+  updateAvailable: boolean;
+  currentVersion: string;
+  latestVersion: string;
+};
+
+/**
+ * Fetches an anonymous bearer token from ghcr.io for the public image.
+ */
+async function getGhcrToken(): Promise<string> {
+  const url = `https://ghcr.io/token?scope=repository:${GHCR_IMAGE}:pull`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "Overlord-Update-Checker" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`GHCR token request failed ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as { token?: string };
+  if (!data.token) throw new Error("GHCR token response missing token field");
+  return data.token;
+}
+
+/**
+ * Lists all tags for the image from the OCI distribution API.
+ */
+async function listGhcrTags(token: string): Promise<string[]> {
+  const url = `https://ghcr.io/v2/${GHCR_IMAGE}/tags/list`;
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "Overlord-Update-Checker",
+      Authorization: `Bearer ${token}`,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`GHCR tags list failed ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as { tags?: string[] };
+  return data.tags || [];
+}
+
+/**
+ * Finds the highest semver tag from a list of tag strings.
+ */
+export function findHighestSemverTag(tags: string[]): string | null {
+  let best: [number, number, number] | null = null;
+  let bestRaw = "";
+
+  for (const tag of tags) {
+    const parsed = parseVersion(tag);
+    if (!parsed) continue;
+    if (
+      !best ||
+      parsed[0] > best[0] ||
+      (parsed[0] === best[0] && parsed[1] > best[1]) ||
+      (parsed[0] === best[0] && parsed[1] === best[1] && parsed[2] > best[2])
+    ) {
+      best = parsed;
+      bestRaw = tag.replace(/^v/, "");
+    }
+  }
+
+  return bestRaw || null;
+}
+
+/**
+ * Queries the GHCR OCI registry for the latest semver image tag and compares
+ * it to the current running version.
+ */
+export async function checkForUpdate(currentVersion: string): Promise<UpdateCheckResult> {
+  const token = await getGhcrToken();
+  const tags = await listGhcrTags(token);
+
+  const latestTag = findHighestSemverTag(tags);
+  if (!latestTag) {
+    logger.warn("[update] No semver tags found on GHCR");
+    return {
+      updateAvailable: false,
+      currentVersion,
+      latestVersion: currentVersion,
+    };
+  }
+
+  const updateAvailable = isNewerVersion(currentVersion, latestTag);
+
+  return {
+    updateAvailable,
+    currentVersion,
+    latestVersion: latestTag,
+  };
+}
+
+// ---- Trigger / status file helpers ----
+
+export type UpdateRequest = {
+  requestedAt: number;
+  requestedBy: string;
+  targetVersion: string;
+};
+
+export type UpdateStatus = {
+  state: "idle" | "pending" | "pulling" | "restarting" | "done" | "error";
+  message: string;
+  progress: number; // 0-100
+  updatedAt: number;
+  targetVersion?: string;
+  log?: string[];
+};
+
+const DEFAULT_STATUS: UpdateStatus = {
+  state: "idle",
+  message: "No update in progress.",
+  progress: 0,
+  updatedAt: 0,
+};
+
+export async function clearUpdateStatus(): Promise<void> {
+  try {
+    const { unlink } = await import("fs/promises");
+    await unlink(UPDATE_STATUS_FILE);
+  } catch {
+    // File may not exist — that's fine
+  }
+}
+
+export async function writeUpdateRequest(req: UpdateRequest): Promise<void> {
+  await Bun.write(UPDATE_REQUEST_FILE, JSON.stringify(req, null, 2));
+  logger.info(`[update] Update request written for version ${req.targetVersion}`);
+}
+
+export async function readUpdateStatus(): Promise<UpdateStatus> {
+  try {
+    const file = Bun.file(UPDATE_STATUS_FILE);
+    if (!(await file.exists())) return { ...DEFAULT_STATUS };
+    const text = await file.text();
+    const data = JSON.parse(text);
+    return {
+      state: data.state || "idle",
+      message: data.message || "",
+      progress: Number(data.progress) || 0,
+      updatedAt: Number(data.updatedAt) || 0,
+      targetVersion: data.targetVersion,
+      log: Array.isArray(data.log) ? data.log : undefined,
+    };
+  } catch {
+    return { ...DEFAULT_STATUS };
+  }
+}
+
+/** Check whether a pending request file exists that hasn't been picked up yet. */
+export async function hasPendingRequest(): Promise<boolean> {
+  try {
+    const file = Bun.file(UPDATE_REQUEST_FILE);
+    return await file.exists();
+  } catch {
+    return false;
+  }
+}

--- a/Overlord-Server/src/version.ts
+++ b/Overlord-Server/src/version.ts
@@ -1,1 +1,1 @@
-export const SERVER_VERSION = "1.7.3";
+export const SERVER_VERSION = "1.8.0";

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -55,11 +55,34 @@ services:
       - no-new-privileges:true
     healthcheck:
       # Use http:// when OVERLORD_TLS_OFFLOAD=true.
-      test: ["CMD-SHELL", "curl -f ${OVERLORD_HEALTHCHECK_URL:-https://localhost:5173/health} >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "curl -fk ${OVERLORD_HEALTHCHECK_URL:-https://localhost:5173/health} >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  overlord-updater:
+    build:
+      context: .
+      dockerfile: docker/updater.Dockerfile
+    container_name: overlord-updater
+    volumes:
+      - overlord-data:/app/data
+      - //./pipe/docker_engine://./pipe/docker_engine
+      - ./docker-compose.windows.yml:/app/docker-compose.yml:ro
+    environment:
+      OVERLORD_DATA_DIR: /app/data
+      OVERLORD_ROOT: /app
+      # Keep the project name consistent so compose targets the right containers
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-overlord}
+      # Port is fixed at 5173 internally on Windows (mapped via ports:)
+      PORT: 5173
+      HOST: 0.0.0.0
+      OVERLORD_HEALTHCHECK_URL: ${OVERLORD_HEALTHCHECK_URL:-}
+      OVERLORD_TLS_OFFLOAD: ${OVERLORD_TLS_OFFLOAD:-false}
+    restart: unless-stopped
+    depends_on:
+      - overlord-server
 
 volumes:
   overlord-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,34 @@ services:
       - no-new-privileges:true
     healthcheck:
       # Use http:// when OVERLORD_TLS_OFFLOAD=true.
-      test: ["CMD-SHELL", "curl -f ${OVERLORD_HEALTHCHECK_URL:-https://localhost:5173/health} >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "curl -fk ${OVERLORD_HEALTHCHECK_URL:-https://localhost:${PORT:-5173}/health} >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  overlord-updater:
+    build:
+      context: .
+      dockerfile: docker/updater.Dockerfile
+    container_name: overlord-updater
+    volumes:
+      - overlord-data:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./docker-compose.yml:/app/docker-compose.yml:ro
+    environment:
+      OVERLORD_DATA_DIR: /app/data
+      OVERLORD_ROOT: /app
+      # Keep the project name consistent so compose targets the right containers
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-overlord}
+      # Pass through variables the sidecar needs when re-invoking compose for updates
+      PORT: ${PORT:-5173}
+      HOST: ${HOST:-0.0.0.0}
+      OVERLORD_HEALTHCHECK_URL: ${OVERLORD_HEALTHCHECK_URL:-}
+      OVERLORD_TLS_OFFLOAD: ${OVERLORD_TLS_OFFLOAD:-false}
+    restart: unless-stopped
+    depends_on:
+      - overlord-server
 
 volumes:
   overlord-data:

--- a/docker/updater.Dockerfile
+++ b/docker/updater.Dockerfile
@@ -1,0 +1,11 @@
+# Overlord in-app update daemon sidecar
+# Watches for update-request.json written by the webapp and performs
+# docker pull + compose restart on the host via the mounted Docker socket.
+FROM docker:27-cli
+
+RUN apk add --no-cache bash jq
+
+COPY scripts/overlord-updater.sh /usr/local/bin/overlord-updater.sh
+RUN chmod +x /usr/local/bin/overlord-updater.sh
+
+CMD ["/usr/local/bin/overlord-updater.sh"]

--- a/scripts/overlord-updater.service
+++ b/scripts/overlord-updater.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Overlord In-App Update Daemon
+Documentation=https://github.com/vxaboveground/Overlord
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+# ---- Adjust this path to match your Overlord installation ----
+WorkingDirectory=/opt/Overlord
+ExecStart=/opt/Overlord/scripts/overlord-updater.sh
+Restart=on-failure
+RestartSec=10
+
+# Run as root since Docker commands require it (or use a docker-capable user)
+User=root
+Group=root
+
+# Environment overrides (uncomment and adjust as needed)
+# Environment=OVERLORD_ROOT=/opt/Overlord
+# Environment=OVERLORD_DATA_DIR=/var/lib/docker/volumes/overlord-data/_data
+# Environment=POLL_INTERVAL=5
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=overlord-updater
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/overlord-updater.sh
+++ b/scripts/overlord-updater.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# ============================================================================
+# overlord-updater.sh — Host-side update daemon for Overlord
+#
+# Watches a trigger file written by the in-app updater API and performs the
+# actual docker image pull + restart cycle on the host.
+#
+# Usage:
+#   ./scripts/overlord-updater.sh              # run in foreground
+#   systemctl start overlord-updater           # run as systemd service
+#
+# The daemon polls every POLL_INTERVAL seconds for a trigger file at:
+#   <DATA_DIR>/update-request.json
+#
+# Progress is written to:
+#   <DATA_DIR>/update-status.json
+#
+# Environment variables:
+#   OVERLORD_ROOT       — Path to the Overlord repo (default: parent of scripts/)
+#   OVERLORD_DATA_DIR   — Path to the data directory (default: Docker volume mount)
+#   POLL_INTERVAL       — Seconds between polls (default: 5)
+#   DOCKER_IMAGE        — Full image reference (default: ghcr.io/vxaboveground/overlord)
+# ============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OVERLORD_ROOT="${OVERLORD_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+COMPOSE_FILE="$OVERLORD_ROOT/docker-compose.yml"
+
+DOCKER_IMAGE="${DOCKER_IMAGE:-ghcr.io/vxaboveground/overlord}"
+
+# Determine the data directory. When Docker uses a named volume, the path is
+# typically /var/lib/docker/volumes/overlord-data/_data. Allow override.
+if [ -z "${OVERLORD_DATA_DIR:-}" ]; then
+  # Try to discover from Docker named volume
+  OVERLORD_DATA_DIR="$(docker volume inspect overlord-data --format '{{ .Mountpoint }}' 2>/dev/null || true)"
+  if [ -z "$OVERLORD_DATA_DIR" ] || [ ! -d "$OVERLORD_DATA_DIR" ]; then
+    # Fallback: local data dir in repo
+    OVERLORD_DATA_DIR="$OVERLORD_ROOT/data"
+  fi
+fi
+
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+REQUEST_FILE="$OVERLORD_DATA_DIR/update-request.json"
+STATUS_FILE="$OVERLORD_DATA_DIR/update-status.json"
+
+echo "[overlord-updater] Root:     $OVERLORD_ROOT"
+echo "[overlord-updater] Data dir: $OVERLORD_DATA_DIR"
+echo "[overlord-updater] Image:    $DOCKER_IMAGE"
+echo "[overlord-updater] Polling every ${POLL_INTERVAL}s for: $REQUEST_FILE"
+
+# ---- Helpers ----
+
+write_status() {
+  local state="$1"
+  local message="$2"
+  local progress="$3"
+  local target_version="${4:-}"
+  local log_line="${5:-}"
+
+  # Build log array incrementally
+  local existing_log="[]"
+  if [ -f "$STATUS_FILE" ]; then
+    existing_log="$(jq -r '.log // []' "$STATUS_FILE" 2>/dev/null || echo '[]')"
+  fi
+
+  if [ -n "$log_line" ]; then
+    existing_log="$(echo "$existing_log" | jq --arg l "$log_line" '. + [$l]')"
+  fi
+
+  # Reset log on new update cycle
+  if [ "$state" = "pending" ] && [ "$progress" = "0" ]; then
+    existing_log="[]"
+    if [ -n "$log_line" ]; then
+      existing_log="$(echo '[]' | jq --arg l "$log_line" '. + [$l]')"
+    fi
+  fi
+
+  jq -n \
+    --arg state "$state" \
+    --arg message "$message" \
+    --argjson progress "$progress" \
+    --argjson updatedAt "$(date +%s000)" \
+    --arg targetVersion "$target_version" \
+    --argjson log "$existing_log" \
+    '{state: $state, message: $message, progress: $progress, updatedAt: $updatedAt, targetVersion: $targetVersion, log: $log}' \
+    > "$STATUS_FILE"
+}
+
+cleanup_request() {
+  rm -f "$REQUEST_FILE"
+}
+
+# ---- Main update procedure ----
+
+run_update() {
+  local target_version
+  target_version="$(jq -r '.targetVersion // "unknown"' "$REQUEST_FILE" 2>/dev/null || echo "unknown")"
+  local requested_by
+  requested_by="$(jq -r '.requestedBy // "unknown"' "$REQUEST_FILE" 2>/dev/null || echo "unknown")"
+
+  echo "[overlord-updater] Update requested by $requested_by to version $target_version"
+
+  write_status "pending" "Update request received. Starting..." 5 "$target_version" "Update requested by $requested_by for version $target_version"
+
+  # Step 1: Pull the new image from GHCR
+  local image_ref="${DOCKER_IMAGE}:${target_version}"
+  write_status "pulling" "Pulling image ${image_ref} from registry..." 15 "$target_version" "Running: docker pull ${image_ref}"
+
+  local pull_output
+  if pull_output="$(docker pull "$image_ref" 2>&1)"; then
+    write_status "pulling" "Image pulled successfully." 40 "$target_version" "$pull_output"
+  else
+    write_status "error" "Image pull failed: $pull_output" 15 "$target_version" "ERROR: docker pull failed: $pull_output"
+    cleanup_request
+    return 1
+  fi
+
+  # Step 2 + 3: Recreate only the server container with the new image.
+  # We deliberately target overlord-server only — bringing the whole stack
+  # down would kill this updater sidecar before it could restart anything.
+  write_status "restarting" "Recreating server container with new image..." 55 "$target_version" "Running: DOCKER_IMAGE=${image_ref} docker compose up -d overlord-server"
+
+  local compose_up_output
+  if compose_up_output="$(DOCKER_IMAGE="$image_ref" docker compose -f "$COMPOSE_FILE" up -d overlord-server 2>&1)"; then
+    write_status "restarting" "Container started. Waiting for health check..." 80 "$target_version" "$compose_up_output"
+  else
+    write_status "error" "docker compose up failed: $compose_up_output" 60 "$target_version" "ERROR: docker compose up failed: $compose_up_output"
+    cleanup_request
+    return 1
+  fi
+
+  # Step 4: Wait for health check
+  local max_wait=120
+  local waited=0
+  while [ $waited -lt $max_wait ]; do
+    local health
+    health="$(docker inspect --format='{{.State.Health.Status}}' overlord-server 2>/dev/null || echo "unknown")"
+    if [ "$health" = "healthy" ]; then
+      break
+    fi
+    sleep 5
+    waited=$((waited + 5))
+    local pct=$((80 + (waited * 15 / max_wait)))
+    write_status "restarting" "Waiting for container health... ($waited/${max_wait}s)" "$pct" "$target_version"
+  done
+
+  cleanup_request
+
+  local final_health
+  final_health="$(docker inspect --format='{{.State.Health.Status}}' overlord-server 2>/dev/null || echo "unknown")"
+
+  if [ "$final_health" = "healthy" ]; then
+    write_status "done" "Update to $target_version completed successfully." 100 "$target_version" "Container is healthy. Update complete."
+    echo "[overlord-updater] Update to $target_version completed successfully."
+  else
+    write_status "done" "Update to $target_version applied. Container health: $final_health (may still be starting)." 100 "$target_version" "Container health: $final_health. May need more time to start."
+    echo "[overlord-updater] Update applied but health is: $final_health"
+  fi
+}
+
+# ---- Poll loop ----
+
+trap 'echo "[overlord-updater] Shutting down."; exit 0' SIGTERM SIGINT
+
+while true; do
+  if [ -f "$REQUEST_FILE" ]; then
+    run_update || true
+  fi
+  sleep "$POLL_INTERVAL"
+done

--- a/scripts/update-overlord.sh
+++ b/scripts/update-overlord.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Manual one-shot updater — pulls latest GHCR image and restarts.
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT/docker-compose.yml"
+DOCKER_IMAGE="${DOCKER_IMAGE:-ghcr.io/vxaboveground/overlord:latest}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found" >&2
+  exit 1
+fi
+
+echo "[1/3] Pulling latest image: $DOCKER_IMAGE"
+docker pull "$DOCKER_IMAGE"
+
+echo "[2/3] Restarting Overlord..."
+DOCKER_IMAGE="$DOCKER_IMAGE" docker compose -f "$COMPOSE_FILE" up -d
+
+echo "[3/3] Status"
+docker compose -f "$COMPOSE_FILE" ps


### PR DESCRIPTION
Adds a self-contained update system that notifies admins when a newer version is available on GHCR and performs the pull/restart entirely within the docker-compose stack via a sidecar container.

- update-checker.ts: GHCR OCI tag polling, semver comparison, request/ status file helpers, and clearUpdateStatus for post-update reset
- misc-routes.ts: /api/update/check, /api/update/start, /api/update/status, /api/update/reset endpoints (admin-only)
- settings.html + settings.js: Software Update section with check, progress log, and auto-reset on completion; fixes infinite reload loop on done state
- docker/updater.Dockerfile: minimal docker:27-cli + bash + jq sidecar image
- docker-compose.yml: overlord-updater sidecar service; mounts docker socket and data volume; passes PORT and other env vars through so compose-within- compose resolves the correct healthcheck URL
- scripts/overlord-updater.sh: poll daemon that pulls new image and recreates overlord-server only (not the whole stack, to avoid self-termination)
- scripts/overlord-updater.service: systemd unit for bare-metal deployments