### PR TITLE
cleaned up the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,385 +4,144 @@
 
 # Overlord
 
-# [TELEGRAM SERVER JOIN NOW NO EXCUSES WE GIVE SUPPORT AND IT'S FUN](https://t.me/WindowsBatch)
+Support and discussion: [Telegram](https://t.me/WindowsBatch)
 
-Hello, I made this project for fun.
+Personal project, shared as-is.
 
-The server is TypeScript on Node/Bun. The client is Go. Operators talk to the server through a web panel or the Electron desktop app, and agents connect over encrypted WebSockets.
+## What is Overlord?
 
-Docker is the easiest way to run it.
+Overlord is a self-hosted command-and-control framework. The server is written in
+TypeScript and runs on Node or Bun. The client (agent) is written in Go. Operators
+interact with the server through a web panel or the Electron desktop app, and agents
+connect over encrypted WebSockets.
+
+Docker is the recommended way to run it.
 
 ---
 
 - [Quick Start (Docker)](#quick-start-docker)
-  - [Windows](#windows)
-  - [Linux](#linux)
-  - [macOS](#macos)
-- [No Docker (.bat / .sh)](#no-docker-bat--sh)
-- [Production Package Scripts](#production-package-scripts)
-- [Docker Notes (TLS, reverse proxy, cache)](#docker-notes-tls-reverse-proxy-cache)
+- [Without Docker](#without-docker)
+- [Production Package](#production-package)
+- [Docker Notes](#docker-notes)
 
 ---
 
 ## Quick Start (Docker)
 
-Pick your OS below. Each section is self-contained: install Docker, get the project, start it.
-
-> Windows and macOS use `docker-compose.windows.yml`. Linux uses the default `docker-compose.yml` (host networking).
-
-After the first start, open `https://localhost:5173`. Default login is `admin` / `admin` unless you set `OVERLORD_USER` / `OVERLORD_PASS`. First startup writes generated secrets to `data/save.json` (inside the container: `/app/data/save.json`) — keep that file private and back it up.
-
----
-
-### Windows
-
-<details>
-<summary>Step-by-step: Windows</summary>
-<br>
-
-**1. Install Docker Desktop**
-
-Either from the website:
-
-- https://docs.docker.com/desktop/setup/install/windows-install/
-
-Or with winget:
-
-```powershell
-winget install -e --id Docker.DockerDesktop
-```
-
-Start Docker Desktop once, then verify:
-
-```powershell
-docker --version
-docker compose version
-```
-
-**2. Get the project**
-
-```powershell
-git clone https://github.com/vxaboveground/Overlord.git
-cd Overlord
-```
-
-**3. Start it**
-
-```powershell
-docker compose -f docker-compose.windows.yml up -d
-```
-
-**4. Open the panel**
-
-```text
-https://localhost:5173
-```
-
-**5. Update later**
-
-```powershell
-docker compose -f docker-compose.windows.yml down
-docker compose -f docker-compose.windows.yml pull
-docker compose -f docker-compose.windows.yml up -d
-```
-
-**6. Stop**
-
-```powershell
-docker compose -f docker-compose.windows.yml down
-```
-
-</details>
-
----
-
-### Linux
-
-<details>
-<summary>Step-by-step: Linux (Debian / Ubuntu / Kali)</summary>
-<br>
-
-**1. Install Docker**
-
-Official docs: https://docs.docker.com/engine/install/debian/
-
-Set up Docker's apt repository:
-
-```bash
-# Add Docker's official GPG key:
-sudo apt update
-sudo apt install ca-certificates curl
-sudo install -m 0755 -d /etc/apt/keyrings
-sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-# Add the repository to Apt sources:
-sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
-Types: deb
-URIs: https://download.docker.com/linux/debian
-Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
-Components: stable
-Architectures: $(dpkg --print-architecture)
-Signed-By: /etc/apt/keyrings/docker.asc
-EOF
-
-sudo apt update
-```
-
-On a derivative distro (e.g. Kali), replace the codename expansion with the matching Debian codename, e.g. `bookworm`.
-
-Install Docker:
-
-```bash
-sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-```
-
-Make sure the daemon is running:
-
-```bash
-sudo systemctl status docker
-```
-
-**2. Grab the compose file**
-
-Make a folder for it, drop in the file, and you're done:
-
-```bash
-mkdir overlord && cd overlord
-wget https://raw.githubusercontent.com/vxaboveground/Overlord/refs/heads/main/docker-compose.yml
-```
-
-No `wget`? Use `curl`:
-
-```bash
-mkdir overlord && cd overlord
-curl -O https://raw.githubusercontent.com/vxaboveground/Overlord/refs/heads/main/docker-compose.yml
-```
-
-**3. Start it**
-
-```bash
-docker compose up -d
-```
-
-The image is pulled automatically from `ghcr.io/vxaboveground/overlord:latest` on first run.
-
-**4. Open the panel**
-
-```text
-https://localhost:5173
-
-or 
-
-https://IP:5173
-```
-
-**5. Update later**
-
-From the same folder:
-
-```bash
-docker compose down
-docker compose pull
-docker compose up -d
-```
-
-**6. Stop**
-
-```bash
-docker compose down
-```
-
-</details>
-
----
-
-### macOS
-
-<details>
-<summary>Step-by-step: macOS</summary>
-<br>
-
-**1. Install Docker Desktop**
-
-Either from the website:
-
-- https://docs.docker.com/desktop/setup/install/mac-install/
-
-Or with Homebrew:
-
-```bash
-brew install --cask docker
-```
-
-Start Docker Desktop once, then verify:
-
-```bash
-docker --version
-docker compose version
-```
-
-**2. Get the project**
+Install Docker for your OS by following the official guide:
+<https://docs.docker.com/get-started/get-docker/>. Once `docker --version` and
+`docker compose version` work, continue below.
+
+Clone the repository:
 
 ```bash
 git clone https://github.com/vxaboveground/Overlord.git
 cd Overlord
 ```
 
-**3. Start it**
+Start the stack:
 
-macOS uses the same compose file as Windows:
+- **Linux** (host networking):
 
-```bash
-docker compose -f docker-compose.windows.yml up -d
-```
+  ```bash
+  docker compose up -d
+  ```
 
-**4. Open the panel**
+- **Windows / macOS**:
 
-```text
-https://localhost:5173
-```
+  ```bash
+  docker compose -f docker-compose.windows.yml up -d
+  ```
 
-**5. Update later**
+Open the panel at <https://localhost:5173>. The default login is `admin` / `admin`
+unless you set `OVERLORD_USER` / `OVERLORD_PASS`. On first startup, generated
+secrets are written to `data/save.json` (inside the container at
+`/app/data/save.json`). Keep that file private and back it up.
 
-```bash
-docker compose -f docker-compose.windows.yml down
-docker compose -f docker-compose.windows.yml pull
-docker compose -f docker-compose.windows.yml up -d
-```
-
-**6. Stop**
-
-```bash
-docker compose -f docker-compose.windows.yml down
-```
-
-</details>
+To update, run the same compose command with `down`, `pull`, then `up -d`. To stop,
+run `down`.
 
 ---
 
-## No Docker (.bat / .sh)
+## Without Docker
 
-If you don't want Docker, use the included scripts.
+You can run Overlord directly from the included scripts. You'll need:
 
-Prerequisites:
-
-- Bun in PATH
-- Go 1.21+ in PATH
+- [Bun](https://bun.sh) in `PATH`
+- Go 1.21+ in `PATH`
 
 ### Windows
 
-Development mode (starts server + client):
-
 ```bat
-start-dev.bat
-```
-
-Production mode (build + run server executable):
-
-```bat
-start-prod.bat
-```
-
-Build client binaries (adds client builds to the build queue):
-
-```bat
-build-clients.bat
+start-dev.bat        :: dev mode (server + client)
+start-prod.bat       :: production mode (build + run)
+build-clients.bat    :: queue client builds
 ```
 
 ### Linux / macOS
 
-Make scripts executable once:
+Make the scripts executable once:
 
 ```bash
 chmod +x start-dev.sh start-dev-server.sh start-dev-client.sh start-prod.sh build-prod-package.sh
 ```
 
-Development mode (server in background, client in foreground):
+Then:
 
 ```bash
-./start-dev.sh
-```
-
-Only server, or only client:
-
-```bash
-./start-dev.sh server
-./start-dev.sh client
-```
-
-Production mode:
-
-```bash
-./start-prod.sh
+./start-dev.sh           # server in background, client in foreground
+./start-dev.sh server    # server only
+./start-dev.sh client    # client only
+./start-prod.sh          # production mode
 ```
 
 ---
 
-## Production Package Scripts
+## Production Package
 
-Build a production-ready package where the server can still build client binaries at runtime.
+Build a production-ready package. The packaged server can still build client
+binaries at runtime.
 
-Windows:
-
-```bat
-build-prod-package.bat
-```
-
-Output: `release/`
-
-Linux / macOS:
-
-```bash
-./build-prod-package.sh
-```
-
-Output: `release/prod-package/`
+| OS              | Command                     | Output                  |
+| --------------- | --------------------------- | ----------------------- |
+| Windows         | `build-prod-package.bat`    | `release/`              |
+| Linux / macOS   | `./build-prod-package.sh`   | `release/prod-package/` |
 
 ---
 
-## Docker Notes (TLS, reverse proxy, cache)
+## Docker Notes
 
-Notes on configs and workarounds.
+### BuildKit cache
 
-### BuildKit cache for faster rebuilds
-
-`docker-compose.yml` ships with `build.cache_from` and `build.cache_to` pointing at `.docker-cache/buildx`. Local builds reuse it automatically — no extra setup.
+`docker-compose.yml` already wires `build.cache_from` and `build.cache_to` to
+`.docker-cache/buildx`. Local rebuilds reuse it automatically.
 
 ### Runtime client build cache
 
-The compose setup uses a persistent volume for runtime client builds:
+A persistent volume is used for client builds produced at runtime:
 
 - Volume: `overlord-client-build-cache`
 - Mount: `/app/client-build-cache`
 - Env: `OVERLORD_CLIENT_BUILD_CACHE_DIR` (default `/app/client-build-cache`)
 
-### Certbot TLS
+### Certbot (Let's Encrypt)
 
-To use Let's Encrypt certificates in production Docker:
+To use Let's Encrypt certificates in production:
 
-1. Set `OVERLORD_TLS_CERTBOT_ENABLED=true`
-2. Set `OVERLORD_TLS_CERTBOT_DOMAIN=your-domain.com`
-3. Mount letsencrypt into the container read-only, e.g. `/etc/letsencrypt:/etc/letsencrypt:ro`
+1. Set `OVERLORD_TLS_CERTBOT_ENABLED=true`.
+2. Set `OVERLORD_TLS_CERTBOT_DOMAIN=your-domain.com`.
+3. Mount `/etc/letsencrypt` into the container read-only:
+   `/etc/letsencrypt:/etc/letsencrypt:ro`.
 
-Default cert paths:
+Default cert paths are `/etc/letsencrypt/live/<domain>/{fullchain,privkey,chain}.pem`.
+Override individually with `OVERLORD_TLS_CERTBOT_LIVE_PATH`,
+`OVERLORD_TLS_CERTBOT_CERT_FILE`, `OVERLORD_TLS_CERTBOT_KEY_FILE`, or
+`OVERLORD_TLS_CERTBOT_CA_FILE`.
 
-```
-cert: /etc/letsencrypt/live/<domain>/fullchain.pem
-key:  /etc/letsencrypt/live/<domain>/privkey.pem
-ca:   /etc/letsencrypt/live/<domain>/chain.pem
-```
+### Reverse proxy / TLS offload
 
-Override with:
-
-- `OVERLORD_TLS_CERTBOT_LIVE_PATH`
-- `OVERLORD_TLS_CERTBOT_CERT_FILE`
-- `OVERLORD_TLS_CERTBOT_KEY_FILE`
-- `OVERLORD_TLS_CERTBOT_CA_FILE`
-
-### Reverse proxy TLS offload
-
-If your platform terminates TLS before traffic reaches Overlord (Render, Caddy, nginx, etc.), set:
+If your platform terminates TLS in front of Overlord (Render, Caddy, nginx, etc.),
+set:
 
 ```
 OVERLORD_TLS_OFFLOAD=true
@@ -390,14 +149,12 @@ OVERLORD_HEALTHCHECK_URL=http://localhost:5173/health
 OVERLORD_PUBLISH_HOST=127.0.0.1
 ```
 
-When enabled:
+The container will serve internal HTTP on `0.0.0.0:$PORT` while the external URL
+remains `https://...` via the proxy. Don't expose the internal HTTP port directly.
 
-- Container serves internal HTTP on `0.0.0.0:$PORT`
-- External URL stays `https://...` through your platform proxy
-- Health checks should use `http://localhost:$PORT/health` inside the container
-- Don't expose the internal container HTTP port directly to the internet
+### Misc
 
-### Notes
-
-- Keep `HOST=0.0.0.0` inside the container. Limit exposure with `OVERLORD_PUBLISH_HOST`, not the bind host.
-- If your `.env` secret/password contains `$`, escape it as `$$` to avoid Docker Compose variable-expansion warnings.
+- Keep `HOST=0.0.0.0` inside the container. Use `OVERLORD_PUBLISH_HOST` to limit
+  exposure, not the bind host.
+- If a secret or password in `.env` contains `$`, escape it as `$$` to avoid
+  Docker Compose variable-expansion warnings.


### PR DESCRIPTION
the old readme had way too much filler. half of it was just docker's own install docs copy-pasted in for every OS, plus a giant all-caps telegram banner that didn't really say anything about what the project is.

rewrote it so you can actually read it in under a minute:

- short "what is overlord?" blurb at the top so people know whats up
- merged the windows/linux/macos quick start into one section, the only real difference is which compose file you use
- removed the big pasted apt block for linux and just linked docker's official install page, people can follow that
- production package section is a tiny table now instead of two near-identical blocks
- kept the docker notes (tls, certbot, reverse proxy, cache) but cleared it up a little

tg channel is still there, so no worries about that.

wrote this by hand, ai only used to audit any typos.