### PR TITLE
builder: add Grab Public IP button and /api/public-ip proxy endpoint

### DIFF
--- a/Overlord-Server/public/assets/build.js
+++ b/Overlord-Server/public/assets/build.js
@@ -854,6 +854,31 @@ if (rawServerListCheckbox && serverUrlInput) {
   });
 }
 
+const grabPublicIpBtn = document.getElementById("grab-public-ip-btn");
+if (grabPublicIpBtn && serverUrlInput) {
+  grabPublicIpBtn.addEventListener("click", async () => {
+    grabPublicIpBtn.disabled = true;
+    const origHTML = grabPublicIpBtn.innerHTML;
+    grabPublicIpBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Fetching...';
+    try {
+      const resp = await fetch("/api/public-ip");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const { ip } = await resp.json();
+      if (!ip) throw new Error("Empty response");
+      const port = window.location.port || (window.location.protocol === "https:" ? "443" : "80");
+      serverUrlInput.value = rawServerListCheckbox?.checked
+        ? `${window.location.protocol}//${ip}:${port}/list.txt`
+        : `${ip}:${port}`;
+      updateServerUrlHintMode();
+    } catch (e) {
+      alert("Could not fetch public IP: " + (e.message || "Unknown error"));
+    } finally {
+      grabPublicIpBtn.disabled = false;
+      grabPublicIpBtn.innerHTML = origHTML;
+    }
+  });
+}
+
 const rawServerListHelpBtn = document.getElementById("raw-server-list-help");
 const rawServerListModal = document.getElementById("raw-server-list-modal");
 const rawServerListModalClose = document.getElementById("raw-server-list-modal-close");

--- a/Overlord-Server/public/build.html
+++ b/Overlord-Server/public/build.html
@@ -350,8 +350,14 @@
 
                     <div>
                       <label class="block text-sm font-medium text-slate-300 mb-2" for="server-url">Server URL</label>
-                      <input type="text" id="server-url" name="server-url"
-                        class="w-full px-3 py-2 bg-slate-800/60 border border-slate-700 rounded-lg focus:outline-none focus:border-blue-500 transition-colors" />
+                      <div class="flex gap-2">
+                        <input type="text" id="server-url" name="server-url"
+                          class="w-full px-3 py-2 bg-slate-800/60 border border-slate-700 rounded-lg focus:outline-none focus:border-blue-500 transition-colors" />
+                        <button type="button" id="grab-public-ip-btn" title="Grab public IP and fill in IP:PORT"
+                          class="shrink-0 px-3 py-2 bg-slate-800/60 border border-slate-700 rounded-lg text-slate-300 hover:bg-slate-700 hover:border-slate-600 transition-colors">
+                          <i class="fa-solid fa-globe"></i> Grab Public IP
+                        </button>
+                      </div>
                       <p id="server-url-hint" class="text-xs text-slate-500 mt-1">
                         Just enter your domain or IP:PORT — no <code class="text-slate-400">wss://</code>, <code class="text-slate-400">https://</code>, or any other prefix.
                       </p>

--- a/Overlord-Server/src/server/routes/misc-routes.ts
+++ b/Overlord-Server/src/server/routes/misc-routes.ts
@@ -470,6 +470,27 @@ export async function handleMiscRoutes(
     return new Response("ok", { headers: deps.CORS_HEADERS });
   }
 
+  if (req.method === "GET" && url.pathname === "/api/public-ip") {
+    try {
+      const resp = await fetch("https://api.ipify.org?format=text", { signal: AbortSignal.timeout(8000) });
+      if (!resp.ok) {
+        return new Response(JSON.stringify({ error: "Upstream IP service unavailable" }), {
+          status: 502,
+          headers: { ...deps.CORS_HEADERS, "Content-Type": "application/json" },
+        });
+      }
+      const ip = (await resp.text()).trim();
+      return new Response(JSON.stringify({ ip }), {
+        headers: { ...deps.CORS_HEADERS, "Content-Type": "application/json" },
+      });
+    } catch {
+      return new Response(JSON.stringify({ error: "Failed to fetch public IP" }), {
+        status: 502,
+        headers: { ...deps.CORS_HEADERS, "Content-Type": "application/json" },
+      });
+    }
+  }
+
   if (req.method === "GET" && url.pathname === "/api/version") {
     return new Response(JSON.stringify({ version: deps.SERVER_VERSION }), {
       headers: {


### PR DESCRIPTION
Adds a "Grab Public IP" button next to the Server URL input on the builder page. Clicking it calls a new /api/public-ip server endpoint (which proxies api.ipify.org to avoid CSP violations) and fills the IP:PORT field using the client's public IP and the current server port.